### PR TITLE
Fix things for IE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Unreleased
   To take advantage of this, make sure to also style scrollbars on elements with an [`[up-viewport]`](/up-viewport) attribute.
 - Polyfill `window.console` and several properties (`log`, `debug`, `info`,
   `warn`, `error`, `group`, `groupCollapsed`, `groupEnd`)
+- Fix tests for IE9 and IE10 by marking more specs as "only with CSS transitions
+  enabled"
 
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Unreleased
   This fixes the case where an `[up-instant]` link removes its parent and thus a `click` event never bubbles up to the body.
 - When opening a modal, elements behind the dialog can now be moved correctly when scrollbars have custom styles on `::-webkit-scrollbar`.
   To take advantage of this, make sure to also style scrollbars on elements with an [`[up-viewport]`](/up-viewport) attribute.
+- Polyfill `window.console` and several properties (`log`, `debug`, `info`,
+  `warn`, `error`, `group`, `groupCollapsed`, `groupEnd`)
 
 
 ### Breaking changes

--- a/lib/assets/javascripts/unpoly/browser.js.coffee
+++ b/lib/assets/javascripts/unpoly/browser.js.coffee
@@ -53,13 +53,12 @@ up.browser = (($) ->
   @internal
   ###
   puts = (stream, args...) ->
-    u.isDefined(console[stream]) or stream = 'log'
     if canLogSubstitution()
-      console[stream]?(args...)
+      console[stream](args...)
     else
       # IE <= 9 cannot pass varargs to console.log using Function#apply because IE
       message = sprintf(args...)
-      console[stream]?(message)
+      console[stream](message)
 
   CONSOLE_PLACEHOLDERS = /\%[odisf]/g
 
@@ -113,6 +112,8 @@ up.browser = (($) ->
   @internal
   ###
   sprintfWithFormattedArgs = (formatter, message, args...) ->
+    return '' if u.isBlank(message)
+
     i = 0
     message.replace CONSOLE_PLACEHOLDERS, ->
       arg = args[i]
@@ -271,9 +272,10 @@ up.browser = (($) ->
   @internal
   ###
   installPolyfills = ->
-    console.group ||= (args...) -> puts('group', args...)
-    console.groupCollapsed ||= (args...) -> puts('groupCollapsed', args...)
-    console.groupEnd ||= (args...) -> puts('groupEnd', args...)
+    window.console ?= {} # Missing in IE9 with DevTools closed
+    for method in ['debug', 'info', 'warn', 'error', 'group', 'groupCollapsed', 'groupEnd']
+      console[method] ?= (args...) -> puts('log', args...)
+    console.log ?= u.noop # Cannot be faked
 
   ###*
   @internal

--- a/lib/assets/javascripts/unpoly/log.js.coffee
+++ b/lib/assets/javascripts/unpoly/log.js.coffee
@@ -97,7 +97,7 @@ up.log = (($) ->
       try
         block()
       finally
-        console.groupEnd() if message
+        b.puts('groupEnd') if message
     else
       block()
 

--- a/lib/assets/javascripts/unpoly/proxy.js.coffee
+++ b/lib/assets/javascripts/unpoly/proxy.js.coffee
@@ -231,8 +231,6 @@ up.proxy = (($) ->
       loadStarted()
       promise.always(loadEnded)
 
-    console.groupEnd()
-
     promise
 
   ###*

--- a/lib/assets/javascripts/unpoly/syntax.js.coffee
+++ b/lib/assets/javascripts/unpoly/syntax.js.coffee
@@ -50,7 +50,7 @@ up.syntax = (($) ->
         // your code here
       });
 
-  The functions will be called on elements maching `.action` when
+  The functions will be called on elements matching `.action` when
   the page loads, or whenever a matching fragment is [updated through Unpoly](/up.replace)
   later.
 

--- a/spec_app/spec/javascripts/up/flow_spec.js.coffee
+++ b/spec_app/spec/javascripts/up/flow_spec.js.coffee
@@ -161,7 +161,6 @@ describe 'up.flow', ->
           it 'adds params from a { data } option to the URL of a GET request', ->
             promise = up.replace('.middle', '/path', data: { 'foo-key': 'foo value', 'bar-key': 'bar value' })
             @respond()
-            console.log("EXPECTATION COMING UP AGAINST %o", location.pathname)
             expect(location.href).toEndWith('/path?foo-key=foo%20value&bar-key=bar%20value')
 
           describe 'if a URL is given as { history } option', ->
@@ -802,9 +801,7 @@ describe 'up.flow', ->
             <div class="keeper" up-keep>old-text</div>
             """
 
-          console.log '*** before hello ***'
           up.hello($container)
-          console.log '*** after hello ***'
           expect(compiler.calls.count()).toEqual(1)
 
           up.extract '.container', """

--- a/spec_app/spec/javascripts/up/flow_spec.js.coffee
+++ b/spec_app/spec/javascripts/up/flow_spec.js.coffee
@@ -598,75 +598,85 @@ describe 'up.flow', ->
 
       describe 'with { transition } option', ->
 
-        it 'morphs between the old and new element', (done) ->
-          affix('.element').text('version 1')
-          up.extract('.element', '<div class="element">version 2</div>', transition: 'cross-fade', duration: 200)
+        describeCapability 'canCssTransition', ->
 
-          $ghost1 = $('.element.up-ghost:contains("version 1")')
-          expect($ghost1).toHaveLength(1)
-          expect(u.opacity($ghost1)).toBeAround(1.0, 0.1)
+          it 'morphs between the old and new element', (done) ->
+            affix('.element').text('version 1')
+            up.extract('.element', '<div class="element">version 2</div>', transition: 'cross-fade', duration: 200)
 
-          $ghost2 = $('.element.up-ghost:contains("version 2")')
-          expect($ghost2).toHaveLength(1)
-          expect(u.opacity($ghost2)).toBeAround(0.0, 0.1)
+            $ghost1 = $('.element.up-ghost:contains("version 1")')
+            expect($ghost1).toHaveLength(1)
+            expect(u.opacity($ghost1)).toBeAround(1.0, 0.1)
 
-          u.setTimer 190, ->
-            expect(u.opacity($ghost1)).toBeAround(0.0, 0.3)
-            expect(u.opacity($ghost2)).toBeAround(1.0, 0.3)
-            done()
+            $ghost2 = $('.element.up-ghost:contains("version 2")')
+            expect($ghost2).toHaveLength(1)
+            expect(u.opacity($ghost2)).toBeAround(0.0, 0.1)
 
-        it 'marks the old fragment and its ghost as .up-destroying during the transition', ->
-          affix('.element').text('version 1')
-          up.extract('.element', '<div class="element">version 2</div>', transition: 'cross-fade', duration: 200)
+            u.setTimer 190, ->
+              expect(u.opacity($ghost1)).toBeAround(0.0, 0.3)
+              expect(u.opacity($ghost2)).toBeAround(1.0, 0.3)
+              done()
 
-          $version1 = $('.element:not(.up-ghost):contains("version 1")')
-          $version1Ghost = $('.element.up-ghost:contains("version 1")')
-          expect($version1).toHaveLength(1)
-          expect($version1Ghost).toHaveLength(1)
-          expect($version1).toHaveClass('up-destroying')
-          expect($version1Ghost).toHaveClass('up-destroying')
+          it 'marks the old fragment and its ghost as .up-destroying during the transition', ->
+            affix('.element').text('version 1')
+            up.extract('.element', '<div class="element">version 2</div>', transition: 'cross-fade', duration: 200)
 
-          $version2 = $('.element:not(.up-ghost):contains("version 2")')
-          $version2Ghost = $('.element.up-ghost:contains("version 2")')
-          expect($version2).toHaveLength(1)
-          expect($version2Ghost).toHaveLength(1)
-          expect($version2).not.toHaveClass('up-destroying')
-          expect($version2Ghost).not.toHaveClass('up-destroying')
+            $version1 = $('.element:not(.up-ghost):contains("version 1")')
+            $version1Ghost = $('.element.up-ghost:contains("version 1")')
+            expect($version1).toHaveLength(1)
+            expect($version1Ghost).toHaveLength(1)
+            expect($version1).toHaveClass('up-destroying')
+            expect($version1Ghost).toHaveClass('up-destroying')
 
-        it 'cancels an existing transition by instantly jumping to the last frame', ->
-          affix('.element').text('version 1')
-          up.extract('.element', '<div class="element">version 2</div>', transition: 'cross-fade', duration: 200)
+            $version2 = $('.element:not(.up-ghost):contains("version 2")')
+            $version2Ghost = $('.element.up-ghost:contains("version 2")')
+            expect($version2).toHaveLength(1)
+            expect($version2Ghost).toHaveLength(1)
+            expect($version2).not.toHaveClass('up-destroying')
+            expect($version2Ghost).not.toHaveClass('up-destroying')
 
-          $ghost1 = $('.element.up-ghost:contains("version 1")')
-          expect($ghost1).toHaveLength(1)
-          expect($ghost1.css('opacity')).toBeAround(1.0, 0.1)
+          it 'cancels an existing transition by instantly jumping to the last frame', ->
+            affix('.element').text('version 1')
+            up.extract('.element', '<div class="element">version 2</div>', transition: 'cross-fade', duration: 200)
 
-          $ghost2 = $('.element.up-ghost:contains("version 2")')
-          expect($ghost2).toHaveLength(1)
-          expect($ghost2.css('opacity')).toBeAround(0.0, 0.1)
+            $ghost1 = $('.element.up-ghost:contains("version 1")')
+            expect($ghost1).toHaveLength(1)
+            expect($ghost1.css('opacity')).toBeAround(1.0, 0.1)
 
-          up.extract('.element', '<div class="element">version 3</div>', transition: 'cross-fade', duration: 200)
+            $ghost2 = $('.element.up-ghost:contains("version 2")')
+            expect($ghost2).toHaveLength(1)
+            expect($ghost2.css('opacity')).toBeAround(0.0, 0.1)
 
-          $ghost1 = $('.element.up-ghost:contains("version 1")')
-          expect($ghost1).toHaveLength(0)
+            up.extract('.element', '<div class="element">version 3</div>', transition: 'cross-fade', duration: 200)
 
-          $ghost2 = $('.element.up-ghost:contains("version 2")')
-          expect($ghost2).toHaveLength(1)
-          expect($ghost2.css('opacity')).toBeAround(1.0, 0.1)
+            $ghost1 = $('.element.up-ghost:contains("version 1")')
+            expect($ghost1).toHaveLength(0)
 
-          $ghost3 = $('.element.up-ghost:contains("version 3")')
-          expect($ghost3).toHaveLength(1)
-          expect($ghost3.css('opacity')).toBeAround(0.0, 0.1)
+            $ghost2 = $('.element.up-ghost:contains("version 2")')
+            expect($ghost2).toHaveLength(1)
+            expect($ghost2.css('opacity')).toBeAround(1.0, 0.1)
 
-        it 'delays the resolution of the returned promise until the transition is over', (done) ->
-          affix('.element').text('version 1')
-          resolution = jasmine.createSpy()
-          promise = up.extract('.element', '<div class="element">version 2</div>', transition: 'cross-fade', duration: 30)
-          promise.then(resolution)
-          expect(resolution).not.toHaveBeenCalled()
-          u.setTimer 70, ->
-            expect(resolution).toHaveBeenCalled()
-            done()
+            $ghost3 = $('.element.up-ghost:contains("version 3")')
+            expect($ghost3).toHaveLength(1)
+            expect($ghost3.css('opacity')).toBeAround(0.0, 0.1)
+
+          it 'delays the resolution of the returned promise until the transition is over', (done) ->
+            affix('.element').text('version 1')
+            resolution = jasmine.createSpy()
+            promise = up.extract('.element', '<div class="element">version 2</div>', transition: 'cross-fade', duration: 30)
+            promise.then(resolution)
+            expect(resolution).not.toHaveBeenCalled()
+            u.setTimer 70, ->
+              expect(resolution).toHaveBeenCalled()
+              done()
+
+        describeFallback 'canCssTransition', ->
+
+          it 'immediately swaps the old and new elements', ->
+            affix('.element').text('version 1')
+            up.extract('.element', '<div class="element">version 2</div>', transition: 'cross-fade', duration: 200)
+            expect($('.element')).toHaveText('version 2')
+            expect($('.up-ghost')).toHaveLength(0)
 
       describe 'handling of [up-keep] elements', ->
 
@@ -890,29 +900,31 @@ describe 'up.flow', ->
           expect(keptListener).toHaveBeenCalledWith($keeper, { key: 'value1' })
           expect(keptListener).toHaveBeenCalledWith($keeper, { key: 'value2' })
 
-        it "doesn't let the discarded element appear in a transition", (done) ->
-          oldTextDuringTransition = undefined
-          newTextDuringTransition = undefined
-          transition = ($old, $new) ->
-            oldTextDuringTransition = squish($old.text())
-            newTextDuringTransition = squish($new.text())
-            u.resolvedDeferred()
-          $container = affix('.container')
-          $container.html """
-            <div class='foo'>old-foo</div>
-            <div class='bar' up-keep>old-bar</div>
-            """
-          newHtml = """
-            <div class='container'>
-              <div class='foo'>new-foo</div>
-              <div class='bar' up-keep>new-bar</div>
-            </div>
-            """
-          promise = up.extract('.container', newHtml, transition: transition)
-          promise.then ->
-            expect(oldTextDuringTransition).toEqual('old-foo old-bar')
-            expect(newTextDuringTransition).toEqual('new-foo old-bar')
-            done()
+        describeCapability 'canCssTransition', ->
+
+          it "doesn't let the discarded element appear in a transition", (done) ->
+            oldTextDuringTransition = undefined
+            newTextDuringTransition = undefined
+            transition = ($old, $new) ->
+              oldTextDuringTransition = squish($old.text())
+              newTextDuringTransition = squish($new.text())
+              u.resolvedDeferred()
+            $container = affix('.container')
+            $container.html """
+              <div class='foo'>old-foo</div>
+              <div class='bar' up-keep>old-bar</div>
+              """
+            newHtml = """
+              <div class='container'>
+                <div class='foo'>new-foo</div>
+                <div class='bar' up-keep>new-bar</div>
+              </div>
+              """
+            promise = up.extract('.container', newHtml, transition: transition)
+            promise.then ->
+              expect(oldTextDuringTransition).toEqual('old-foo old-bar')
+              expect(newTextDuringTransition).toEqual('new-foo old-bar')
+              done()
 
     describe 'up.destroy', ->
       

--- a/spec_app/spec/javascripts/up/link_spec.js.coffee
+++ b/spec_app/spec/javascripts/up/link_spec.js.coffee
@@ -367,22 +367,24 @@ describe 'up.link', ->
 
         describe 'with [up-transition] modifier', ->
 
-          it 'morphs between the old and new target element', (done) ->
-            affix('.target.old')
-            $link = affix('a[href="/path"][up-target=".target"][up-transition="cross-fade"][up-duration="300"][up-easing="linear"]')
-            $link.click()
-            @respondWith '<div class="target new">new text</div>'
+          describeCapability 'canCssTransition', ->
 
-            $oldGhost = $('.target.old.up-ghost')
-            $newGhost = $('.target.new.up-ghost')
-            expect($oldGhost).toExist()
-            expect($newGhost).toExist()
-            expect(u.opacity($oldGhost)).toBeAround(1, 0.15)
-            expect(u.opacity($newGhost)).toBeAround(0, 0.15)
-            u.setTimer 150, ->
-              expect(u.opacity($oldGhost)).toBeAround(0.5, 0.15)
-              expect(u.opacity($newGhost)).toBeAround(0.5, 0.15)
-              done()
+            it 'morphs between the old and new target element', (done) ->
+              affix('.target.old')
+              $link = affix('a[href="/path"][up-target=".target"][up-transition="cross-fade"][up-duration="300"][up-easing="linear"]')
+              $link.click()
+              @respondWith '<div class="target new">new text</div>'
+
+              $oldGhost = $('.target.old.up-ghost')
+              $newGhost = $('.target.new.up-ghost')
+              expect($oldGhost).toExist()
+              expect($newGhost).toExist()
+              expect(u.opacity($oldGhost)).toBeAround(1, 0.15)
+              expect(u.opacity($newGhost)).toBeAround(0, 0.15)
+              u.setTimer 150, ->
+                expect(u.opacity($oldGhost)).toBeAround(0.5, 0.15)
+                expect(u.opacity($newGhost)).toBeAround(0.5, 0.15)
+                done()
 
       it 'does not add a history entry when an up-history attribute is set to "false"', ->
         oldPathname = location.pathname

--- a/spec_app/spec/javascripts/up/motion_spec.js.coffee
+++ b/spec_app/spec/javascripts/up/motion_spec.js.coffee
@@ -60,101 +60,115 @@ describe 'up.motion', ->
 
       describe 'when called with an element or selector', ->
 
-        it 'cancels an existing animation on the given element by instantly jumping to the last frame', ->
-          $element = affix('.element').text('content')
-          up.animate($element, { 'font-size': '40px', 'opacity': '0.33' }, duration: 10000)
-          up.motion.finish($element)
-          expect($element.css('font-size')).toEqual('40px')
-          expect($element.css('opacity')).toEqual('0.33')
+        describeCapability 'canCssTransition', ->
 
-        it 'cancels animations on children of the given element', ->
-          $parent = affix('.element')
-          $child = $parent.affix('.child')
-          up.animate($child, { 'font-size': '40px' }, duration: 10000)
-          up.motion.finish($parent)
-          expect($child.css('font-size')).toEqual('40px')
+          it 'cancels an existing animation on the given element by instantly jumping to the last frame', ->
+            $element = affix('.element').text('content')
+            up.animate($element, { 'font-size': '40px', 'opacity': '0.33' }, duration: 10000)
+            up.motion.finish($element)
+            expect($element.css('font-size')).toEqual('40px')
+            expect($element.css('opacity')).toEqual('0.33')
 
-        it 'does not cancel animations on other elements', ->
-          $element1 = affix('.element1').text('content1')
-          $element2 = affix('.element2').text('content2')
-          up.animate($element1, 'fade-in', duration: 10000)
-          up.animate($element2, 'fade-in', duration: 10000)
-          up.motion.finish($element1)
-          expect(Number($element1.css('opacity'))).toEqual(1)
-          expect(Number($element2.css('opacity'))).toEqual(0, 0.1)
+          it 'cancels animations on children of the given element', ->
+            $parent = affix('.element')
+            $child = $parent.affix('.child')
+            up.animate($child, { 'font-size': '40px' }, duration: 10000)
+            up.motion.finish($parent)
+            expect($child.css('font-size')).toEqual('40px')
 
-        it 'restores existing transitions on the element', ->
-          $element = affix('.element').text('content')
-          $element.css('transition': 'font-size 3s ease')
-          oldTransitionProperty = $element.css('transition-property')
-          expect(oldTransitionProperty).toContain('font-size') # be paranoid
-          up.animate($element, 'fade-in', duration: 10000)
-          up.motion.finish($element)
-          expect(u.opacity($element)).toEqual(1)
-          currentTransitionProperty = $element.css('transition-property')
-          expect(currentTransitionProperty).toEqual(oldTransitionProperty)
-          expect(currentTransitionProperty).toContain('font-size')
-          expect(currentTransitionProperty).not.toContain('opacity')
+          it 'does not cancel animations on other elements', ->
+            $element1 = affix('.element1').text('content1')
+            $element2 = affix('.element2').text('content2')
+            up.animate($element1, 'fade-in', duration: 10000)
+            up.animate($element2, 'fade-in', duration: 10000)
+            up.motion.finish($element1)
+            expect(Number($element1.css('opacity'))).toEqual(1)
+            expect(Number($element2.css('opacity'))).toEqual(0, 0.1)
 
-        it 'cancels an existing transition on the element by instantly jumping to the last frame', ->
-          $old = affix('.old').text('old content')
-          $new = affix('.new').text('new content')
+          it 'restores existing transitions on the element', ->
+            $element = affix('.element').text('content')
+            $element.css('transition': 'font-size 3s ease')
+            oldTransitionProperty = $element.css('transition-property')
+            expect(oldTransitionProperty).toBeDefined()
+            expect(oldTransitionProperty).toContain('font-size') # be paranoid
+            up.animate($element, 'fade-in', duration: 10000)
+            up.motion.finish($element)
+            expect(u.opacity($element)).toEqual(1)
+            currentTransitionProperty = $element.css('transition-property')
+            expect(currentTransitionProperty).toEqual(oldTransitionProperty)
+            expect(currentTransitionProperty).toContain('font-size')
+            expect(currentTransitionProperty).not.toContain('opacity')
 
-          up.morph($old, $new, 'cross-fade', duration: 2000)
-          expect($('.up-ghost').length).toBe(2)
+          it 'cancels an existing transition on the element by instantly jumping to the last frame', ->
+            $old = affix('.old').text('old content')
+            $new = affix('.new').text('new content')
 
-          up.motion.finish($old)
+            up.morph($old, $new, 'cross-fade', duration: 2000)
+            expect($('.up-ghost').length).toBe(2)
 
-          expect($('.up-ghost').length).toBe(0)
-          expect($old.css('display')).toEqual('none')
-          expect($new.css('display')).toEqual('block')
+            up.motion.finish($old)
 
-        it 'can be called on either element involved in a transition', ->
-          $old = affix('.old').text('old content')
-          $new = affix('.new').text('new content')
+            expect($('.up-ghost').length).toBe(0)
+            expect($old.css('display')).toEqual('none')
+            expect($new.css('display')).toEqual('block')
 
-          up.morph($old, $new, 'cross-fade', duration: 2000)
-          expect($('.up-ghost').length).toBe(2)
+          it 'can be called on either element involved in a transition', ->
+            $old = affix('.old').text('old content')
+            $new = affix('.new').text('new content')
 
-          up.motion.finish($new)
+            up.morph($old, $new, 'cross-fade', duration: 2000)
+            expect($('.up-ghost').length).toBe(2)
 
-          expect($('.up-ghost').length).toBe(0)
-          expect($old.css('display')).toEqual('none')
-          expect($new.css('display')).toEqual('block')
+            up.motion.finish($new)
+
+            expect($('.up-ghost').length).toBe(0)
+            expect($old.css('display')).toEqual('none')
+            expect($new.css('display')).toEqual('block')
 
 
-        it 'cancels transitions on children of the given element', ->
-          $parent = affix('.parent')
-          $old = $parent.affix('.old').text('old content')
-          $new = $parent.affix('.new').text('new content')
+          it 'cancels transitions on children of the given element', ->
+            $parent = affix('.parent')
+            $old = $parent.affix('.old').text('old content')
+            $new = $parent.affix('.new').text('new content')
 
-          up.morph($old, $new, 'cross-fade', duration: 2000)
-          expect($('.up-ghost').length).toBe(2)
+            up.morph($old, $new, 'cross-fade', duration: 2000)
+            expect($('.up-ghost').length).toBe(2)
 
-          up.motion.finish($parent)
+            up.motion.finish($parent)
 
-          expect($('.up-ghost').length).toBe(0)
-          expect($old.css('display')).toEqual('none')
-          expect($new.css('display')).toEqual('block')
+            expect($('.up-ghost').length).toBe(0)
+            expect($old.css('display')).toEqual('none')
+            expect($new.css('display')).toEqual('block')
+
+        describeFallback 'canCssTransition', ->
+
+          it 'does nothing'
 
       describe 'when called without arguments', ->
 
-        it 'cancels all animations on the screen', ->
-          $element1 = affix('.element1').text('content1')
-          $element2 = affix('.element2').text('content2')
+        describeCapability 'canCssTransition', ->
 
-          up.animate($element1, 'fade-in', duration: 3000)
-          up.animate($element2, 'fade-in', duration: 3000)
+          it 'cancels all animations on the screen', ->
+            $element1 = affix('.element1').text('content1')
+            $element2 = affix('.element2').text('content2')
 
-          expect(u.opacity($element1)).toBeAround(0.0, 0.1)
-          expect(u.opacity($element2)).toBeAround(0.0, 0.1)
+            up.animate($element1, 'fade-in', duration: 3000)
+            up.animate($element2, 'fade-in', duration: 3000)
 
-          up.motion.finish()
+            expect(u.opacity($element1)).toBeAround(0.0, 0.1)
+            expect(u.opacity($element2)).toBeAround(0.0, 0.1)
 
-          $element1 = $('.element1')
-          $element2 = $('.element2')
-          expect(u.opacity($element1)).toBe(1.0)
-          expect(u.opacity($element2)).toBe(1.0)
+            up.motion.finish()
+
+            $element1 = $('.element1')
+            $element2 = $('.element2')
+            expect(u.opacity($element1)).toBe(1.0)
+            expect(u.opacity($element2)).toBe(1.0)
+
+        describeFallback 'canCssTransition', ->
+
+          it 'does nothing'
+
 
     describe 'up.morph', ->
 

--- a/spec_app/spec/javascripts/up/popup_spec.js.coffee
+++ b/spec_app/spec/javascripts/up/popup_spec.js.coffee
@@ -102,50 +102,50 @@ describe 'up.popup', ->
                 expect($('.container')).toHaveText('response2')
                 done()
 
-        it 'closes the current popup and wait for its close animation to finish before starting the open animation of a second popup', (done) ->
-          $span = affix('span')
-          up.popup.config.openAnimation = 'fade-in'
-          up.popup.config.openDuration = 5
-          up.popup.config.closeAnimation = 'fade-out'
-          up.popup.config.closeDuration = 50
+        describeCapability 'canCssTransition', ->
 
-          events = []
-          u.each ['up:popup:open', 'up:popup:opened', 'up:popup:close', 'up:popup:closed'], (event) ->
-            up.on event, ->
-              events.push(event)
+          it 'closes the current popup and wait for its close animation to finish before starting the open animation of a second popup', (done) ->
+            $span = affix('span')
+            up.popup.config.openAnimation = 'fade-in'
+            up.popup.config.openDuration = 5
+            up.popup.config.closeAnimation = 'fade-out'
+            up.popup.config.closeDuration = 50
 
-          up.popup.attach($span, { target: '.target', html: '<div class="target">response1</div>' })
+            events = []
+            u.each ['up:popup:open', 'up:popup:opened', 'up:popup:close', 'up:popup:closed'], (event) ->
+              up.on event, ->
+                events.push(event)
 
-          # First popup is starting opening animation
-          expect(events).toEqual ['up:popup:open']
-          expect($('.target')).toHaveText('response1')
+            up.popup.attach($span, { target: '.target', html: '<div class="target">response1</div>' })
 
-          u.setTimer 30, ->
-            # First popup has completed opening animation
-            expect(events).toEqual ['up:popup:open', 'up:popup:opened']
+            # First popup is starting opening animation
+            expect(events).toEqual ['up:popup:open']
             expect($('.target')).toHaveText('response1')
 
-            up.popup.attach($span, { target: '.target', html: '<div class="target">response2</div>' })
+            u.setTimer 30, ->
+              # First popup has completed opening animation
+              expect(events).toEqual ['up:popup:open', 'up:popup:opened']
+              expect($('.target')).toHaveText('response1')
 
-            # First popup is starting close animation. Second popup waits for that.
-            expect(events).toEqual ['up:popup:open', 'up:popup:opened', 'up:popup:open', 'up:popup:close']
-            expect($('.target')).toHaveText('response1')
+              up.popup.attach($span, { target: '.target', html: '<div class="target">response2</div>' })
 
-            u.setTimer 15, ->
-
-              # Second popup is still waiting for first popup's closing animaton to finish.
+              # First popup is starting close animation. Second popup waits for that.
               expect(events).toEqual ['up:popup:open', 'up:popup:opened', 'up:popup:open', 'up:popup:close']
               expect($('.target')).toHaveText('response1')
 
-              u.setTimer 100, ->
+              u.setTimer 15, ->
 
-                # First popup has finished closing, second popup has finished opening.
-                expect(events).toEqual ['up:popup:open', 'up:popup:opened', 'up:popup:open', 'up:popup:close', 'up:popup:closed', 'up:popup:opened']
-                expect($('.target')).toHaveText('response2')
+                # Second popup is still waiting for first popup's closing animaton to finish.
+                expect(events).toEqual ['up:popup:open', 'up:popup:opened', 'up:popup:open', 'up:popup:close']
+                expect($('.target')).toHaveText('response1')
 
-                done()
+                u.setTimer 100, ->
 
+                  # First popup has finished closing, second popup has finished opening.
+                  expect(events).toEqual ['up:popup:open', 'up:popup:opened', 'up:popup:open', 'up:popup:close', 'up:popup:closed', 'up:popup:opened']
+                  expect($('.target')).toHaveText('response2')
 
+                  done()
 
     describe 'up.popup.coveredUrl', ->
 


### PR DESCRIPTION
Fix Unpoly and its specs for IE9 and IE10 by marking more specs as "only with CSS transitions enabled". and polyfilling `window.console` and several properties (`log`, `debug`, `info`,  `warn`, `error`, `group`, `groupCollapsed`, `groupEnd`).

+ Typo fix

