### PR TITLE
Autoclose URL issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Unreleased
 ### Compatible changes
 
 - Fix a bug where the back button would not work if the document contained carriage returns (`\r`).
+- Fix a bug where auto-closed modals and popups would overwrite a changed
+  browser location with their cached "covered URL"
 
 
 ### Breaking changes

--- a/lib/assets/javascripts/unpoly/modal.js.coffee
+++ b/lib/assets/javascripts/unpoly/modal.js.coffee
@@ -189,6 +189,10 @@ up.modal = (($) ->
     else
       template
 
+  discardHistory = ->
+    state.coveredTitle = null
+    state.coveredUrl = null
+
   createFrame = (target, options) ->
     $modal = $(templateHtml())
     $modal.attr('up-flavor', state.flavor)
@@ -519,7 +523,9 @@ up.modal = (($) ->
   ###
 
   autoclose = ->
-    closeAsap() unless state.sticky
+    unless state.sticky
+      discardHistory()
+      closeAsap()
 
   ###*
   Returns whether the given element or selector is contained

--- a/lib/assets/javascripts/unpoly/popup.js.coffee
+++ b/lib/assets/javascripts/unpoly/popup.js.coffee
@@ -149,6 +149,10 @@ up.popup = (($) ->
     state.$popup.attr('up-position', state.position)
     state.$popup.css(css)
 
+  discardHistory = ->
+    state.coveredTitle = null
+    state.coveredUrl = null
+
   createFrame = (target) ->
     $popup = u.$createElementFromSelector('.up-popup')
     # Create an empty element that will match the
@@ -329,7 +333,9 @@ up.popup = (($) ->
   ###
       
   autoclose = ->
-    closeAsap() unless state.sticky
+    unless state.sticky
+      discardHistory()
+      closeAsap()
 
   ###*
   Returns whether the given element or selector is contained

--- a/spec_app/spec/javascripts/up/modal_spec.js.coffee
+++ b/spec_app/spec/javascripts/up/modal_spec.js.coffee
@@ -463,6 +463,23 @@ describe 'up.modal', ->
         expect($('.outside')).toHaveText('new outside')
         expect($('.up-modal')).not.toExist()
 
+      it 'does not restore the covered URL when auto-closing', (done) ->
+        up.motion.config.enabled = true
+        up.modal.config.openDuration = 0
+        up.modal.config.closeDuration = 20
+
+        affix('.outside').text('old outside')
+        whenModalOpen = up.modal.visit('/path', target: '.inside')
+        @respondWith("<div class='inside'>old inside</div>") # Populate modal
+
+        whenModalOpen.then ->
+          up.extract('.outside', "<div class='outside'>new outside</div>",
+            origin: $('.inside'), history: '/new-location') # Provoke auto-close
+
+          u.setTimer 50, ->
+            expect(location.href).toEndWith '/new-location'
+            done()
+
       it 'does not auto-close the modal when a replacement from inside the modal affects a selector inside the modal', ->
         affix('.outside').text('old outside')
         up.modal.visit('/path', target: '.inside')

--- a/spec_app/spec/javascripts/up/popup_spec.js.coffee
+++ b/spec_app/spec/javascripts/up/popup_spec.js.coffee
@@ -300,7 +300,7 @@ describe 'up.popup', ->
       it 'prefers to replace a selector within the popup', ->
         $outside = affix('.foo').text('old outside')
         $link = affix('.link')
-        up.popup.attach($link, href: '/path', target: '.foo')
+        up.popup.attach($link, target: '.foo')
         @respondWith("<div class='foo'>old inside</div>")
         up.extract('.foo', "<div class='foo'>new text</div>")
         expect($outside).toBeInDOM()
@@ -310,7 +310,7 @@ describe 'up.popup', ->
       it 'auto-closes the popup when a replacement from inside the popup affects a selector behind the popup', ->
         affix('.outside').text('old outside')
         $link = affix('.link')
-        up.popup.attach($link, href: '/path', target: '.inside')
+        up.popup.attach($link, target: '.inside')
         @respondWith("<div class='inside'>old inside</div>")
         up.extract('.outside', "<div class='outside'>new outside</div>", origin: $('.inside'))
         expect($('.outside')).toHaveText('new outside')
@@ -338,7 +338,7 @@ describe 'up.popup', ->
       it 'does not auto-close the popup when a replacement from inside the popup affects a selector inside the popup', ->
         affix('.outside').text('old outside')
         $link = affix('.link')
-        up.popup.attach($link, href: '/path', target: '.inside')
+        up.popup.attach($link, target: '.inside')
         @respondWith("<div class='inside'>old inside</div>")
         up.extract('.inside', "<div class='inside'>new inside</div>", origin: $('.inside'))
         expect($('.inside')).toHaveText('new inside')
@@ -347,7 +347,7 @@ describe 'up.popup', ->
       it 'does not auto-close the popup when a replacement from outside the popup affects a selector outside the popup', ->
         affix('.outside').text('old outside')
         $link = affix('.link')
-        up.popup.attach($link, href: '/path', target: '.inside')
+        up.popup.attach($link, target: '.inside')
         @respondWith("<div class='inside'>old inside</div>")
         up.extract('.outside', "<div class='outside'>new outside</div>", origin: $('.outside'))
         expect($('.outside')).toHaveText('new outside')
@@ -356,7 +356,7 @@ describe 'up.popup', ->
       it 'does not auto-close the popup when a replacement from outside the popup affects a selector inside the popup', ->
         affix('.outside').text('old outside')
         $link = affix('.link')
-        up.popup.attach($link, href: '/path', target: '.inside')
+        up.popup.attach($link, target: '.inside')
         @respondWith("<div class='inside'>old inside</div>")
         up.extract('.inside', "<div class='inside'>new inside</div>", origin: $('.outside'))
         expect($('.inside')).toHaveText('new inside')
@@ -370,7 +370,7 @@ describe 'up.popup', ->
       it 'closes a popup on mousedown (in case an [up-instant] link removes its parent and thus a click event never fires)', ->
         affix('.outside').text('old outside')
         $link = affix('.link')
-        up.popup.attach($link, href: '/path', target: '.inside')
+        up.popup.attach($link, target: '.inside')
         @respondWith("<div class='inside'>inside</div>")
         Trigger.mousedown($('body'))
         expect($('.up-popup')).not.toExist()

--- a/spec_app/spec/javascripts/up/popup_spec.js.coffee
+++ b/spec_app/spec/javascripts/up/popup_spec.js.coffee
@@ -316,6 +316,25 @@ describe 'up.popup', ->
         expect($('.outside')).toHaveText('new outside')
         expect($('.up-popup')).not.toExist()
 
+      it 'does not restore the covered URL when auto-closing', (done) ->
+        up.motion.config.enabled = true
+        up.popup.config.openDuration = 0
+        up.popup.config.closeDuration = 20
+        up.popup.config.history = true
+
+        affix('.outside').text('old outside')
+        $link = affix('.link')
+        whenPopupOpen = up.popup.attach($link, url: '/path', target: '.inside')
+        @respondWith("<div class='inside'>old inside</div>") # Populate popup
+
+        whenPopupOpen.then ->
+          up.extract('.outside', "<div class='outside'>new outside</div>",
+            origin: $('.inside'), history: '/new-location') # Provoke auto-close
+
+          u.setTimer 50, ->
+            expect(location.href).toEndWith '/new-location'
+            done()
+
       it 'does not auto-close the popup when a replacement from inside the popup affects a selector inside the popup', ->
         affix('.outside').text('old outside')
         $link = affix('.link')


### PR DESCRIPTION
Fix a bug where auto-closed modals and popups would overwrite a changed browser location with their cached "covered URL"