### PR TITLE
Introduce up.modal.config.closable=true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Unreleased
 
 ### Compatible changes
 
+- New config option `[up.modal.config](/up.modal.config).closable` (default
+  `true` leaves original behavior unchanged).
+
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Unreleased
 - [Popups](/up.popup) and [modals](/up.modal) will no longer try to restore a covered document title
   and URL if they were opened without pushing a history entry.
 - When fragments are [replaced](/up.replace) without pushing a new history entry,
-  the document title will no longer by changed by default.
+  the document title will no longer be changed by default.
 
 
 ### Breaking changes

--- a/lib/assets/javascripts/unpoly/modal.js.coffee
+++ b/lib/assets/javascripts/unpoly/modal.js.coffee
@@ -655,7 +655,7 @@ up.modal = (($) ->
   # Close the modal when someone clicks outside the dialog
   # (but not on a modal opener).
   up.on('click', 'body', (event, $body) ->
-    return unless config.closable
+    return unless flavorDefault('closable')
 
     $target = $(event.target)
     unless $target.closest('.up-modal-dialog').length || $target.closest('[up-modal]').length
@@ -671,7 +671,8 @@ up.modal = (($) ->
   )
 
   # Close the pop-up overlay when the user presses ESC.
-  up.bus.onEscape(closeAsap)
+  up.bus.onEscape ->
+    closeAsap() if flavorDefault('closable')
 
   ###*
   When this element is clicked, closes a currently open dialog.

--- a/lib/assets/javascripts/unpoly/modal.js.coffee
+++ b/lib/assets/javascripts/unpoly/modal.js.coffee
@@ -91,7 +91,7 @@ up.modal = (($) ->
     You can also supply a function that returns a HTML string.
     The function will be called with the modal options (merged from these defaults
     and any per-open overrides) whenever a modal opens.
-  @param {String} [config.closeLabel='X']
+  @param {String} [config.closeLabel='×']
     The label of the button that closes the dialog.
   @param {Booleam} [config.closable=true]
     When `true`, the modal will render a close icon and close when the user
@@ -135,6 +135,7 @@ up.modal = (($) ->
     backdropCloseAnimation: 'fade-out'
     closeLabel: '×'
     closable: true
+    sticky: false
     flavors: { default: {} }
 
     template: (config) ->

--- a/lib/assets/javascripts/unpoly/modal.js.coffee
+++ b/lib/assets/javascripts/unpoly/modal.js.coffee
@@ -93,6 +93,11 @@ up.modal = (($) ->
     and any per-open overrides) whenever a modal opens.
   @param {String} [config.closeLabel='X']
     The label of the button that closes the dialog.
+  @param {Booleam} [config.closable=true]
+    When `true`, the modal will render a close icon and close when the user
+    clicks outside of it.
+    When `false`, you need to either supply an element with `[up-close]` or
+    close the modal manually with `up.modal.close()`.
   @param {String} [config.openAnimation='fade-in']
     The animation used to open the viewport around the dialog.
   @param {String} [config.closeAnimation='fade-out']
@@ -129,6 +134,7 @@ up.modal = (($) ->
     backdropOpenAnimation: 'fade-in'
     backdropCloseAnimation: 'fade-out'
     closeLabel: '×'
+    closable: true
     flavors: { default: {} }
 
     template: (config) ->
@@ -200,6 +206,7 @@ up.modal = (($) ->
     $dialog.css('width', options.width) if u.isPresent(options.width)
     $dialog.css('max-width', options.maxWidth) if u.isPresent(options.maxWidth)
     $dialog.css('height', options.height) if u.isPresent(options.height)
+    $modal.find('.up-modal-close').remove() unless options.closable
     $content = $modal.find('.up-modal-content')
     # Create an empty element that will match the
     # selector that is being replaced.
@@ -384,6 +391,7 @@ up.modal = (($) ->
     options.sticky = u.option(options.sticky, u.castedAttr($link, 'up-sticky'), flavorDefault('sticky', options.flavor))
     options.confirm = u.option(options.confirm, $link.attr('up-confirm'))
     options.method = up.link.followMethod($link, options)
+    options.closable = flavorDefault('closable', options.flavor)
     options.layer = 'modal'
     animateOptions = up.motion.animateOptions(options, $link, duration: flavorDefault('openDuration', options.flavor), easing: flavorDefault('openEasing', options.flavor))
 
@@ -646,6 +654,8 @@ up.modal = (($) ->
   # Close the modal when someone clicks outside the dialog
   # (but not on a modal opener).
   up.on('click', 'body', (event, $body) ->
+    return unless config.closable
+
     $target = $(event.target)
     unless $target.closest('.up-modal-dialog').length || $target.closest('[up-modal]').length
       closeAsap()

--- a/lib/assets/javascripts/unpoly/util.js.coffee
+++ b/lib/assets/javascripts/unpoly/util.js.coffee
@@ -545,7 +545,7 @@ up.util = (($) ->
 
   Returns the array.
 
-  @function up.util.isDeferred
+  @function up.util.toArray
   @param object
   @return {Array}
   @stable

--- a/spec_app/Gemfile.lock
+++ b/spec_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    unpoly-rails (0.27.2)
+    unpoly-rails (0.27.3)
       rails (>= 3)
 
 GEM

--- a/spec_app/spec/javascripts/up/modal_spec.js.coffee
+++ b/spec_app/spec/javascripts/up/modal_spec.js.coffee
@@ -482,6 +482,18 @@ describe 'up.modal', ->
           expect(wasClosed).toBe(true)
           done()
 
+      it 'closes the modal when the user presses the escape key', (done) ->
+        wasClosed = false
+        up.modal.extract('.modal', '<div class="modal">Modal content</div>', animation: false)
+        up.on 'up:modal:close', ->
+          wasClosed = true
+
+        escapeEvent = $.Event('keydown', keyCode: 27)
+        $('body').trigger(escapeEvent)
+        u.nextFrame ->
+          expect(wasClosed).toBe(true)
+          done()
+
       describe 'with config.closable = false', ->
 
         beforeEach ->
@@ -502,6 +514,18 @@ describe 'up.modal', ->
             wasClosed = true
 
           backdrop.click()
+          u.nextFrame ->
+            expect(wasClosed).toBe(false)
+            done()
+
+        it 'does not close the modal when the user presses the escape key', (done) ->
+          wasClosed = false
+          up.modal.extract('.modal', '<div class="modal">Modal content</div>', animation: false)
+          up.on 'up:modal:close', ->
+            wasClosed = true
+
+          escapeEvent = $.Event('keydown', keyCode: 27)
+          $('body').trigger(escapeEvent)
           u.nextFrame ->
             expect(wasClosed).toBe(false)
             done()

--- a/spec_app/spec/javascripts/up/modal_spec.js.coffee
+++ b/spec_app/spec/javascripts/up/modal_spec.js.coffee
@@ -318,13 +318,24 @@ describe 'up.modal', ->
 
     describe 'up.modal.close', ->
 
-      it 'closes a currently open modal'
+      it 'closes a currently open modal', (done) ->
+        up.modal.extract('.modal', '<div class="modal">Modal content</div>')
 
-      it 'does nothing if no modal is open'
+        modalContent = $('.modal')
+        expect(modalContent).toBeInDOM()
 
-    describe 'up.modal.source', ->
+        up.modal.close().then ->
+          expect(modalContent).not.toBeInDOM()
+          done()
 
-      it 'should have tests'
+      it 'does nothing if no modal is open', (done) ->
+        wasClosed = false
+        up.on 'up:modal:close', ->
+          wasClosed = true
+
+        up.modal.close().then ->
+          expect(wasClosed).toBe(false)
+          done()
 
   describe 'unobtrusive behavior', ->
     
@@ -442,6 +453,58 @@ describe 'up.modal', ->
           $link.click()
           expect(wasClosed).toBe(false)
           expect(wasDefaultPrevented).toBe(false)
+
+    describe 'template behavior', ->
+
+      it 'closes the modal on close icon click', (done) ->
+        wasClosed = false
+        up.modal.extract('.modal', '<div class="modal">Modal content</div>', animation: false)
+
+        closeIcon = $('.up-modal-close')
+        up.on 'up:modal:close', ->
+          wasClosed = true
+
+        closeIcon.click()
+        u.nextFrame ->
+          expect(wasClosed).toBe(true)
+          done()
+
+      it 'closes the modal on backdrop click', (done) ->
+        wasClosed = false
+        up.modal.extract('.modal', '<div class="modal">Modal content</div>', animation: false)
+
+        backdrop = $('.up-modal-backdrop')
+        up.on 'up:modal:close', ->
+          wasClosed = true
+
+        backdrop.click()
+        u.nextFrame ->
+          expect(wasClosed).toBe(true)
+          done()
+
+      describe 'with config.closable = false', ->
+
+        beforeEach ->
+          up.modal.config.closable = false
+
+        it 'does not render a close icon', ->
+          up.modal.extract('.modal', '<div class="modal">Modal content</div>', animation: false)
+
+          modal = $('.up-modal')
+          expect(modal).not.toContainElement('.up-modal-close')
+
+        it 'does not close the modal on backdrop click', (done) ->
+          wasClosed = false
+          up.modal.extract('.modal', '<div class="modal">Modal content</div>', animation: false)
+
+          backdrop = $('.up-modal-backdrop')
+          up.on 'up:modal:close', ->
+            wasClosed = true
+
+          backdrop.click()
+          u.nextFrame ->
+            expect(wasClosed).toBe(false)
+            done()
 
     describe 'when replacing content', ->
 


### PR DESCRIPTION
By setting `up.modal.config.closable = false`, Unpoly will not render a close button inside a modal and will neither close a modal when the backdrop is clicked.