### PR TITLE
Add support for Rails 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ All notable changes to this project will be documented in this file.
 This project mostly adheres to [Semantic Versioning](http://semver.org/).
 
 
-Unreleased
-----------
+0.35.2
+------
 
 ### Compatible changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 This project mostly adheres to [Semantic Versioning](http://semver.org/).
 
 
+Unreleased
+----------
+
+### Compatible changes
+
+- `unpoly-rails` now supports Rails 5
+
+
 0.35.1
 ------
 

--- a/README_RAILS.md
+++ b/README_RAILS.md
@@ -63,7 +63,7 @@ When detecting a validation request, the server is expected to validate (but not
 
 ### Automatic redirect detection
 
-`unpoly-rails` installs a `before_filter` into all controllers which echoes the request's URL as a response header `X-Up-Location` and the request's
+`unpoly-rails` installs a `before_action` into all controllers which echoes the request's URL as a response header `X-Up-Location` and the request's
 HTTP method as `X-Up-Method`.
 
 The Unpoly frontend [requires these headers to detect redirects](http://unpoly.com/form-up-target#redirects), which are otherwise undetectable for an AJAX client.

--- a/lib/unpoly/rails/request_echo_headers.rb
+++ b/lib/unpoly/rails/request_echo_headers.rb
@@ -1,7 +1,7 @@
 module Unpoly
   module Rails
     ##
-    # Installs a `before_filter` into all controllers which echoes the
+    # Installs a `before_action` into all controllers which echoes the
     # request's URL as a response header `X-Up-Location` and the request's
     # HTTP method as `X-Up-Method`.
     #
@@ -10,7 +10,11 @@ module Unpoly
     module RequestEchoHeaders
 
       def self.included(base)
-        base.before_filter :set_up_request_echo_headers
+        if base.respond_to?(:before_action)
+          base.before_action :set_up_request_echo_headers
+        else
+          base.before_filter :set_up_request_echo_headers
+        end
       end
 
       private

--- a/lib/unpoly/rails/request_method_cookie.rb
+++ b/lib/unpoly/rails/request_method_cookie.rb
@@ -1,5 +1,5 @@
 ##
-# Installs a before_filter into all controllers which echoes the
+# Installs a `before_action` into all controllers which echoes the
 # request's method as a cookie named `_up_request_method`.
 #
 # The Unpoly requires this cookie to detect whether the initial page
@@ -16,7 +16,11 @@ module Unpoly
       COOKIE_NAME = '_up_method'
 
       def self.included(base)
-        base.before_filter :set_up_request_method_cookie
+        if base.respond_to?(:before_action)
+          base.before_action :set_up_request_method_cookie
+        else
+          base.before_filter :set_up_request_method_cookie
+        end
       end
 
       private

--- a/lib/unpoly/rails/version.rb
+++ b/lib/unpoly/rails/version.rb
@@ -4,6 +4,6 @@ module Unpoly
     # The current version of the unpoly-rails gem.
     # This version number is also used for releases of the Unpoly
     # frontend code.
-    VERSION = '0.35.1'
+    VERSION = '0.35.2'
   end
 end

--- a/spec_app/Gemfile.lock
+++ b/spec_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    unpoly-rails (0.34.2)
+    unpoly-rails (0.35.2)
       rails (>= 3)
 
 GEM
@@ -218,4 +218,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.12.5
+   1.15.1


### PR DESCRIPTION
Rails 5 removed `before_filter`, so unpoly-rails now uses `before_action` if available.
`before_filter` will be used on older Railses.