### PR TITLE
Avoid Sass deprecation warning for "plus" operator

### DIFF
--- a/lib/assets/stylesheets/unpoly/toast.sass
+++ b/lib/assets/stylesheets/unpoly/toast.sass
@@ -17,7 +17,7 @@ $text-color: #333
 
 .up-toast-variable
   font-weight: normal
-  color: $text-color + 80
+  color: lighten($text-color, 30%)
 
 .up-toast-actions
   margin-top: 7px


### PR DESCRIPTION
This fixes a Sass deprecation warning.

```
DEPRECATION WARNING on line 20 of (...)/gems/unpoly-rails-0.50.0/lib/assets/stylesheets/unpoly/toast.sass:
The operation `#333 plus 80` is deprecated and will be an error in future versions.
Consider using Sass's color functions instead.
http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
```

The resulting color is slightly different, but I guess it's good enough as this currently affects only error messages.