### PR TITLE
Fix up.util.uniq for IE and Edge

### DIFF
--- a/lib/assets/javascripts/unpoly/util.coffee
+++ b/lib/assets/javascripts/unpoly/util.coffee
@@ -711,7 +711,8 @@ up.util = (($) ->
   ###
   uniq = (array) ->
     return array if array.length < 2
-    set = new Set(array)
+    set = new Set()
+    each array, (element) -> set.add(element)
     setToArray(set)
 
   ###*

--- a/spec_app/spec/javascripts/up/motion_spec.js.coffee
+++ b/spec_app/spec/javascripts/up/motion_spec.js.coffee
@@ -427,7 +427,8 @@ describe 'up.motion', ->
         $child = $('<div class="child"></div>').css(margin: '40px').appendTo($element)
         up.motion.prependCopy($element)
         $clonedChild = $('.up-ghost .child')
-        expect($clonedChild.offset()).toEqual($child.offset())
+        expect($clonedChild.offset().top).toBeAround($child.offset().top, 0.5)
+        expect($clonedChild.offset().left).toBeAround($child.offset().left, 0.5)
 
       it 'correctly positions the ghost over an element within a scrolled body', ->
         $body = $('body')


### PR DESCRIPTION
`uniq` from 0.55 won't work in IE11 or Edge, as `new Set(array)` is unsupported. This fixes the issue.

Also fixes an unrelated spec which failed in IE when comparing offsets of cloned elements.