### PR TITLE
fix rename of feedback property navSelectors->navs introduced in 06134f0

### DIFF
--- a/lib/assets/javascripts/unpoly-bootstrap3/feedback-ext.coffee
+++ b/lib/assets/javascripts/unpoly-bootstrap3/feedback-ext.coffee
@@ -2,4 +2,4 @@
 # of a navigation bar.
 up.feedback.config.currentClasses.push('active')
 
-up.feedback.config.navSelectors.push('.nav')
+up.feedback.config.navs.push('.nav')


### PR DESCRIPTION
I noticed that the property got renamed in 06134f0