### PR TITLE
Fix a typo in the documentation

### DIFF
--- a/lib/assets/javascripts/unpoly/syntax.coffee.erb
+++ b/lib/assets/javascripts/unpoly/syntax.coffee.erb
@@ -82,7 +82,7 @@ up.syntax = do ->
   \#\#\# Cleaning up after yourself
 
   If your compiler returns a function, Unpoly will use this as a *destructor* to
-  clean up if the element leaves the DOM. Note that in Unpoly the same DOM ad JavaScript environment
+  clean up if the element leaves the DOM. Note that in Unpoly the same DOM and JavaScript environment
   will persist through many page loads, so it's important to not create
   [memory leaks](https://makandracards.com/makandra/31325-how-to-create-memory-leaks-in-jquery).
 


### PR DESCRIPTION
I fixed a typo in line 8077 of dist/unpoly.js.