### PR TITLE
Fix some typos in documentation

### DIFF
--- a/lib/assets/javascripts/unpoly/fragment.coffee.erb
+++ b/lib/assets/javascripts/unpoly/fragment.coffee.erb
@@ -74,7 +74,7 @@ up.fragment = do ->
 
   \#\#\# Example
 
-  Let's say your curent HTML looks like this:
+  Let's say your current HTML looks like this:
 
       <div class="one">old one</div>
       <div class="two">old two</div>
@@ -314,7 +314,7 @@ up.fragment = do ->
 
   \#\#\# Example
 
-  Let's say your curent HTML looks like this:
+  Let's say your current HTML looks like this:
 
       <div class="one">old one</div>
       <div class="two">old two</div>

--- a/lib/assets/javascripts/unpoly/link.coffee.erb
+++ b/lib/assets/javascripts/unpoly/link.coffee.erb
@@ -16,7 +16,7 @@ This makes for an unfriendly experience:
 - State changes caused by AJAX updates get lost during the page transition.
 - Unsaved form changes get lost during the page transition.
 - The JavaScript VM is reset during the page transition.
-- If the page layout is composed from multiple srollable containers
+- If the page layout is composed from multiple scrollable containers
   (e.g. a pane view), the scroll positions get lost during the page transition.
 - The user sees a "flash" as the browser loads and renders the new page,
   even if large portions of the old and new page are the same (navigation, layout, etc.).

--- a/lib/assets/javascripts/unpoly/syntax.coffee.erb
+++ b/lib/assets/javascripts/unpoly/syntax.coffee.erb
@@ -215,7 +215,7 @@ up.syntax = do ->
   ###**
   Registers a [compiler](/up.compiler) that is run before all other compilers.
 
-  Use `up.macro()` to register a compiler that sets multiply Unpoly attributes.
+  Use `up.macro()` to register a compiler that sets multiple Unpoly attributes.
 
   \#\#\# Example
 


### PR DESCRIPTION
There is also a typo in <https://unpoly.com/tutorial> that you might want to fix yourself (tutorial page does not seem to be part of the repo).

> Have you noticed how noticed how pages fade in