### PR TITLE
Bugfixes in link to /a-up-modal

### DIFF
--- a/dist/unpoly.js
+++ b/dist/unpoly.js
@@ -14762,7 +14762,7 @@ or function.
         var link = document.querySelector('a')
         up.modal.follow(link)
     
-    Any option attributes for [`a[up-modal]`](/a.up-modal) will be honored.
+    Any option attributes for [`a[up-modal]`](/a-up-modal) will be honored.
     
     Emits events [`up:modal:open`](/up:modal:open) and [`up:modal:opened`](/up:modal:opened).
     

--- a/lib/assets/javascripts/unpoly/modal.coffee.erb
+++ b/lib/assets/javascripts/unpoly/modal.coffee.erb
@@ -288,7 +288,7 @@ up.modal = do ->
       var link = document.querySelector('a')
       up.modal.follow(link)
 
-  Any option attributes for [`a[up-modal]`](/a.up-modal) will be honored.
+  Any option attributes for [`a[up-modal]`](/a-up-modal) will be honored.
 
   Emits events [`up:modal:open`](/up:modal:open) and [`up:modal:opened`](/up:modal:opened).
 


### PR DESCRIPTION
Currently, https://unpoly.com/up.modal.follow contains a 404 link to /a.up-modal. 

In this pull request these links have been replaced by /a-up-modal.