### PR TITLE
Restore focus after boot

### DIFF
--- a/lib/assets/javascripts/unpoly/fragment.coffee.erb
+++ b/lib/assets/javascripts/unpoly/fragment.coffee.erb
@@ -896,8 +896,12 @@ up.fragment = do ->
 
   up.on 'up:app:boot', ->
     body = document.body
+    activeElement = document.activeElement
     setSource(body, up.browser.url())
-    hello(body)
+    body = hello(body)
+    if activeElement && body.contains(activeElement)
+      activeElement.focus()
+    body
 
   up.on 'up:framework:reset', reset
 


### PR DESCRIPTION
When `up:app:boot` gets triggered, `up.hello` reinserts the fragment. The focused element loses it's focus, which is noticeable and annoying with a slow connection. Happens, if the javascript tag is on the bottom of the page.

Reproduce (with a login page):
* have a slow connection (dev tools of browser)
* completely refresh login page (with Ctrl + F5)
* while assets are downloading, focus a field that is not focused by default
* wait for javascript to finish loading
* Focused field loses its focus

---

I considered putting the logic into the `up.hello` method, but the javascript will be fast enough anywhere else except `up:app:boot`.