### PR TITLE
[up-modal] should respect cache setting

### DIFF
--- a/lib/assets/javascripts/unpoly/modal.coffee.erb
+++ b/lib/assets/javascripts/unpoly/modal.coffee.erb
@@ -437,6 +437,7 @@ up.modal = do ->
     options.layer = 'modal'
     options.failTarget ?= link.getAttribute('up-fail-target')
     options.failLayer ?= link.getAttribute('up-fail-layer') ? 'auto'
+    options.cache ?= e.booleanAttr(link, 'up-cache')
 
     animateOptions = up.motion.animateOptions(options, link, duration: flavorDefault('openDuration', options.flavor), easing: flavorDefault('openEasing', options.flavor))
 

--- a/spec_app/spec/javascripts/up/modal_spec.js.coffee
+++ b/spec_app/spec/javascripts/up/modal_spec.js.coffee
@@ -563,6 +563,27 @@ describe 'up.modal', ->
           next =>
             expect(@lastRequest().method).toEqual 'POST'
 
+      describe 'with [up-cache] modifier', ->
+        it 'honours the given setting', asyncSpec (next) ->
+          $link = $fixture('a[href="/path"][up-modal=".target"][up-cache="false"]')
+          Trigger.clickSequence($link)
+
+          next =>
+            @respondWith('<div class="target">modal content 1</div>')
+
+          next =>
+            expect('.up-modal .target').toHaveText('modal content 1')
+            history.back()
+
+          next =>
+            Trigger.clickSequence($link)
+
+          next =>
+            @respondWith('<div class="target">modal content 2</div>')
+
+          next =>
+            expect('.up-modal .target').toHaveText('modal content 2')
+
       it 'adds a history entry and allows the user to use the back button', asyncSpec (next) ->
         up.motion.config.enabled = false
         up.history.config.enabled = true


### PR DESCRIPTION
I don't use Jasmine much in my own projects (to the credit of Unpoly eliminating a lot of custom JS) so hopefully I didn't butcher the spec.

Let me know if you think anything needs to be changed.