### PR TITLE
Set utf-8 encoding during asset validation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -79,7 +79,7 @@ namespace :assets do
         raise "Expected build file to exist: #{dist_path}"
       end
 
-      content = File.read(dist_path)
+      content = File.read(dist_path, encoding: "utf-8")
 
       if content.size == 0
         raise "Zero-byte build file: #{dist_path}"


### PR DESCRIPTION
The `dist/unpoly.js` output contains UTF-8 characters that trigger the
following error when performing `assets:validate`.

        ArgumentError: invalid byte sequence in US-ASCII

I'm not aware of any drawbacks to setting this.