### PR TITLE
Escape class name when building target

### DIFF
--- a/lib/assets/javascripts/unpoly/element.coffee
+++ b/lib/assets/javascripts/unpoly/element.coffee
@@ -638,7 +638,7 @@ up.element = do ->
   @internal
   ###
   classSelector = (klass) ->
-    klass = klass.replace(/:/, '\\:')
+    klass = klass.replace(/:/g, '\\:')
     ".#{klass}"
 
   ###**

--- a/lib/assets/javascripts/unpoly/element.coffee
+++ b/lib/assets/javascripts/unpoly/element.coffee
@@ -634,6 +634,14 @@ up.element = do ->
       return attributeSelector('id', id)
 
   ###**
+  @function up.element.classSelector
+  @internal
+  ###
+  classSelector = (klass) ->
+    klass = klass.replace(/:/, '\\:')
+    ".#{klass}"
+
+  ###**
   Always creates a full document with a <html> root, even if the given `html`
   is only a fragment.
 
@@ -1129,6 +1137,7 @@ up.element = do ->
     affix: affix # practical for element creation
     toSelector: toSelector # practical
     idSelector: idSelector
+    classSelector: classSelector
     isSingleton: isSingleton # internal
     isSingletonSelector: isSingletonSelector
     attributeSelector: attributeSelector # internal

--- a/lib/assets/javascripts/unpoly/fragment.coffee
+++ b/lib/assets/javascripts/unpoly/fragment.coffee
@@ -1308,9 +1308,7 @@ up.fragment = do ->
      else if goodClasses = u.presence(u.filter(element.classList, isGoodClassForTarget))
       selector = ''
       for klass in goodClasses
-        # Escape colons in klass to satisfy querySelector
-        klass = klass.replace(/:/, '\\:')
-        selector += ".#{klass}"
+        selector += e.classSelector(klass)
       return selector
      else
        return e.elementTagName(element)

--- a/lib/assets/javascripts/unpoly/fragment.coffee
+++ b/lib/assets/javascripts/unpoly/fragment.coffee
@@ -1308,6 +1308,8 @@ up.fragment = do ->
      else if goodClasses = u.presence(u.filter(element.classList, isGoodClassForTarget))
       selector = ''
       for klass in goodClasses
+        # Escape colons in klass to satisfy querySelector
+        klass = klass.replace(/:/, '\\:')
         selector += ".#{klass}"
       return selector
      else

--- a/spec_app/spec/javascripts/up/element_spec.coffee
+++ b/spec_app/spec/javascripts/up/element_spec.coffee
@@ -965,3 +965,9 @@ describe 'up.element', ->
     it 'returns false for an attached element with { display: none }', ->
       element = fixture('.element', text: 'content', style: { display: 'none' })
       expect(up.element.isVisible(element)).toBe(false)
+
+  describe 'up.element.classSelector', ->
+    it 'escapes all colons', ->
+      element = fixture('div')
+      element.classList.add('print:sm:hidden')
+      expect(up.element.classSelector('print:sm:hidden')).toBe('.print\\:sm\\:hidden')

--- a/spec_app/spec/javascripts/up/fragment_spec.js.coffee
+++ b/spec_app/spec/javascripts/up/fragment_spec.js.coffee
@@ -4906,6 +4906,11 @@ describe 'up.fragment', ->
         element = fixture('div.class1.class2')
         expect(up.fragment.toTarget(element)).toBe(".class1.class2")
 
+      it 'escapes colons in class names', ->
+        element = fixture('div')
+        element.classList.add('block', 'sm:hidden')
+        expect(up.fragment.toTarget(element)).toBe(".block.sm\\:hidden")
+
       it "prefers using the element's [name] attribute to only using the element's tag name", ->
         element = fixture('input[name=name-value]')
         expect(up.fragment.toTarget(element)).toBe('input[name="name-value"]')


### PR DESCRIPTION
Classes with colon's are permitted if the colon is escaped (ie. Tailwind utility classes).

~Appears to break this spec at this line, but I can't seem to figure out why after going through the debug loop. Any thoughts?~ I think you were right and it was browser focus.