### PR TITLE
Allow disabling of banner before booting

### DIFF
--- a/lib/assets/javascripts/unpoly/log.coffee
+++ b/lib/assets/javascripts/unpoly/log.coffee
@@ -10,6 +10,17 @@ Unpoly can print debugging information to the developer console, e.g.:
 
 You can activate logging by calling [`up.log.enable()`](/up.log.enable).
 
+\#\#\# Disabling banner
+
+Set `up.config.banner` before loading Unpoly to disable.
+
+  <script>
+    var up = {
+      config: {
+        banner: false
+      }
+    }
+  </script>
 @module up.log
 ###
 up.log = do ->
@@ -34,7 +45,10 @@ up.log = do ->
   ###
   config = new up.Config ->
     enabled: sessionStore.get('enabled')
-    banner: true
+    banner: if u.isBoolean(up.originalUp?.config?.banner)
+              up.originalUp.config.banner
+            else
+              true
 
   reset = ->
     config.reset()

--- a/lib/assets/javascripts/unpoly/namespace.coffee.erb
+++ b/lib/assets/javascripts/unpoly/namespace.coffee.erb
@@ -3,3 +3,4 @@
 ###
 window.up =
   version: <%= Unpoly::Rails::VERSION.to_json %>
+  originalUp: up if up?


### PR DESCRIPTION
The current config variable isn't available until it's too late.

Instead, allow an `up` object to exist when setting up our
`up` namespace, and copy that object to our new `up`
namespace under the `originalUp` key.

When setting the banner default, use any `originalUp.config.banner`
value that may exist, or fallback to the default of `true`.

Closes #157