### PR TITLE
Print banner after booting app

### DIFF
--- a/lib/assets/javascripts/unpoly/log.coffee
+++ b/lib/assets/javascripts/unpoly/log.coffee
@@ -115,7 +115,7 @@ up.log = do ->
       console.log(logo + text)
 
 
-  up.on 'up:framework:boot', printBanner
+  up.on 'up:app:boot', printBanner
 
   up.on 'up:framework:reset', reset
 


### PR DESCRIPTION
Instead of listening for when the framework has booted, listen for the event
that is fired when the application is booted and the DOM is ready.

At this stage, any changes to up.log.config would be completed, allowing the
banner to be disabled if desired.

Closes #157