### PR TITLE
Use correct date in `X-Up-Reload-From-Time` example

### DIFF
--- a/lib/assets/javascripts/unpoly/protocol.coffee
+++ b/lib/assets/javascripts/unpoly/protocol.coffee
@@ -241,7 +241,7 @@ up.protocol = do ->
 
   The time is encoded is the number of seconds elapsed since the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time).
 
-  For instance, a modification date of December 24th, 1:51:46 PM UTC would produce the following header:
+  For instance, a modification date of December 23th, 1:40:18 PM UTC would produce the following header:
 
   ```http
   X-Up-Target: .unread-count


### PR DESCRIPTION
It seems that the date used in the example is incorrect. When I enter it at https://www.unixtimestamp.com/index.php, I get Wed Dec 23 2020 13:40:18 GMT+0000.