### PR TITLE
Documentation fixes

### DIFF
--- a/lib/assets/javascripts/unpoly/classes/request.coffee
+++ b/lib/assets/javascripts/unpoly/classes/request.coffee
@@ -164,7 +164,7 @@ class up.Request extends up.Record
   ###**
   The element that triggered the request.
 
-  For example, when this request was triggered by a click on a link, the lonk
+  For example, when this request was triggered by a click on a link, the link
   element is set as the `{ origin }`.
 
   To prevent memory leaks, this property is removed shortly after the response is received.

--- a/lib/assets/javascripts/unpoly/fragment.coffee
+++ b/lib/assets/javascripts/unpoly/fragment.coffee
@@ -1298,7 +1298,7 @@ up.fragment = do ->
   so you don't usually need to pass a URL when reloading.
 
   To reload from another URL, pass a `{ url }` option or set an `[up-source]` attribute
-  on the element or its ancestors.
+  on the element being reloaded or its ancestors.
 
   \#\#\# Skipping updates when nothing changed
 


### PR DESCRIPTION
Clarify that the `up-source` attribute needs to be applied to the element being reloaded via `up.reload`.