### PR TITLE
Document method wrapping for non-GET/POST request

### DIFF
--- a/lib/assets/javascripts/unpoly/link.coffee
+++ b/lib/assets/javascripts/unpoly/link.coffee
@@ -801,9 +801,12 @@ up.link = do ->
   @param [up-method='get']
     The HTTP method to use for the request.
 
-    Common values are `get`, `post`, `put`, `patch` and `delete`.  `The value is case insensitive.
+    Common values are `get`, `post`, `put`, `patch` and `delete`. The value is case insensitive.
 
     The HTTP method may also be passed as an `[data-method]` attribute.
+
+    By default, methods other than `get` or `post` will be converted into a `post` request, and carry
+    their original method as a configurable [`_method` parameter](/up.protocol.config#config.methodParam).
 
   @param [up-params]
     A JSON object with additional [parameters](/up.Params) that should be sent as the request's


### PR DESCRIPTION
I'm not sure if it should be mentioned that this is a browser limitation.

Came out of #195