### PR TITLE
Fix docs - Curly braces were parsed as type

### DIFF
--- a/src/unpoly/layer.js
+++ b/src/unpoly/layer.js
@@ -811,7 +811,7 @@ up.layer = (function() {
     The new overlay's [context](/up.layer.context) object, encoded as JSON.
 
   @param [up-position]
-    The position of the popup relative to the `{ origin }` element that opened
+    The position of the popup relative to the `origin` element that opened
     the overlay.
 
     Supported values are `top`,  `right`,  `bottom` and  `left`.
@@ -819,7 +819,7 @@ up.layer = (function() {
     See [popup position](/customizing-overlays#popup-position).
 
   @param [up-align]
-    The alignment of the popup within its `{ position }`.
+    The alignment of the popup within its `position`.
 
     Supported values are `top`,  `right`, `center`, `bottom` and  `left`.
 


### PR DESCRIPTION
These two `@params` don't have types, so the first curly braces were parsed as a type by [this regex](https://github.com/unpoly/unpoly-site/blob/7388e778d55c896aa680fb5b20462b806919bcd4/lib/unpoly/guide/parser.rb#L91), causing a visual bug in the docs.

![CleanShot 2022-09-11 at 15 39 44@2x](https://user-images.githubusercontent.com/14110/189551898-817ac92b-536f-4a6b-8ca7-f84540ccc134.png)
