### PR TITLE
Add xhr property to Request

### DIFF
--- a/spec/unpoly/classes/request_spec.coffee
+++ b/spec/unpoly/classes/request_spec.coffee
@@ -5,10 +5,6 @@ describe 'up.Request', ->
 
   describe 'constructor', ->
 
-    it 'initializes a XMLHttpRequest instance', ->
-      request = new up.Request(url: '/foo', preload: true, cache: false)
-      expect(request.xhr).toEqual(jasmine.any(XMLHttpRequest))
-
     it 'force-enables caching when preloading', ->
       request = new up.Request(url: '/foo', preload: true, cache: false)
       expect(request.cache).toBe(true)
@@ -28,6 +24,12 @@ describe 'up.Request', ->
           expect(request.url).toEqual('/path')
           expect(request.layer).toBeMissing()
           expect(request.context).toBeMissing()
+
+  describe '#xhr', ->
+
+    it 'lazily initializes an XMLHttpRequest instance', ->
+      request = new up.Request(url: '/foo', preload: true, cache: false)
+      expect(request.xhr).toEqual(jasmine.any(XMLHttpRequest))
 
   describe '#url', ->
 

--- a/spec/unpoly/classes/request_spec.coffee
+++ b/spec/unpoly/classes/request_spec.coffee
@@ -5,6 +5,10 @@ describe 'up.Request', ->
 
   describe 'constructor', ->
 
+    it 'initializes a XMLHttpRequest instance', ->
+      request = new up.Request(url: '/foo', preload: true, cache: false)
+      expect(request.xhr).toEqual(jasmine.any(XMLHttpRequest))
+
     it 'force-enables caching when preloading', ->
       request = new up.Request(url: '/foo', preload: true, cache: false)
       expect(request.cache).toBe(true)

--- a/spec/unpoly/network_spec.js
+++ b/spec/unpoly/network_spec.js
@@ -1577,6 +1577,23 @@ describe('up.network', function() {
           })
         })
 
+        it('allows up:request:load listeners to access the xhr request object', function (done) {
+          const listener = jasmine.createSpy('listener').and.callFake(function (event) {
+            expect(jasmine.Ajax.requests.count()).toEqual(0)
+            expect(event.request.xhr).toBeDefined()
+          })
+
+          up.on('up:request:load', listener)
+
+          up.request('/path1', {method: 'post'})
+
+          u.task(() => {
+            expect(listener.calls.count()).toBe(1)
+            expect(jasmine.Ajax.requests.count()).toEqual(1)
+            done()
+          })
+        })
+
         describe('event target', function() {
           it('is emitted on the layer that triggered the event', asyncSpec(function(next) {
             makeLayers(3)

--- a/src/unpoly/classes/request.js
+++ b/src/unpoly/classes/request.js
@@ -367,9 +367,10 @@ up.Request = class Request extends up.Record {
   }
 
   /*-
-  Returns the underlying XMLHttpRequest instance.
+  Returns the underlying `XMLHttpRequest` instance.
 
   @property up.Request#xhr
+  @param {XMLHttpRequest} xhr
   @stable
   */
   get xhr() {

--- a/src/unpoly/classes/request.js
+++ b/src/unpoly/classes/request.js
@@ -366,6 +366,12 @@ up.Request = class Request extends up.Record {
     this.badResponseTime ??= u.evalOption(up.network.config.badResponseTime, this)
   }
 
+  get xhr() {
+    // Initialize the xhr request on first access,
+    // so listeners on up:request:send events have a chance to access the xhr.
+    return this._xhr ??= new XMLHttpRequest()
+  }
+
   /*-
   Returns the elements matched by this request's [target selector](/up.Request.prototype.target).
 
@@ -577,8 +583,8 @@ up.Request = class Request extends up.Record {
   abort({ reason } = {}) {
     // setAbortedState() must be called before xhr.abort(), since xhr's event handlers
     // will call setAbortedState() a second time, without a message.
-    if (this.setAbortedState(reason) && this.xhr) {
-      this.xhr.abort()
+    if (this.setAbortedState(reason) && this._xhr) {
+      this._xhr.abort()
     }
   }
 

--- a/src/unpoly/classes/request.js
+++ b/src/unpoly/classes/request.js
@@ -366,6 +366,11 @@ up.Request = class Request extends up.Record {
     this.badResponseTime ??= u.evalOption(up.network.config.badResponseTime, this)
   }
 
+  /*-
+  Returns the underlying XMLHttpRequest instance.
+
+  @property up.Request#xhr
+  */
   get xhr() {
     // Initialize the xhr request on first access,
     // so listeners on up:request:send events have a chance to access the xhr.

--- a/src/unpoly/classes/request.js
+++ b/src/unpoly/classes/request.js
@@ -494,7 +494,7 @@ up.Request = class Request extends up.Record {
     this.expired = false
 
     // Convert from XHR's callback-based API to up.Request's promise-based API
-    this.xhr = new up.Request.XHRRenderer(this).buildAndSend({
+    new up.Request.XHRRenderer(this).buildAndSend({
       onload:    () => this.onXHRLoad(),
       onerror:   () => this.onXHRError(),
       ontimeout: () => this.onXHRTimeout(),

--- a/src/unpoly/classes/request.js
+++ b/src/unpoly/classes/request.js
@@ -370,6 +370,7 @@ up.Request = class Request extends up.Record {
   Returns the underlying XMLHttpRequest instance.
 
   @property up.Request#xhr
+  @stable
   */
   get xhr() {
     // Initialize the xhr request on first access,

--- a/src/unpoly/classes/request/xhr_renderer.js
+++ b/src/unpoly/classes/request/xhr_renderer.js
@@ -10,7 +10,7 @@ up.Request.XHRRenderer = class XHRRenderer {
   }
 
   buildAndSend(handlers) {
-    this.xhr = new XMLHttpRequest()
+    this.xhr = this.request.xhr ?? new XMLHttpRequest()
 
     // We copy params since we will modify them below.
     // This would confuse API clients and cache key logic in up.network.

--- a/src/unpoly/classes/request/xhr_renderer.js
+++ b/src/unpoly/classes/request/xhr_renderer.js
@@ -10,7 +10,7 @@ up.Request.XHRRenderer = class XHRRenderer {
   }
 
   buildAndSend(handlers) {
-    this.xhr = this.request.xhr ?? new XMLHttpRequest()
+    this.xhr = this.request.xhr
 
     // We copy params since we will modify them below.
     // This would confuse API clients and cache key logic in up.network.


### PR DESCRIPTION
Add up.Request#xhr property which returns the not yet sent XMLHttpRequest object.

With this, it's possible to access the xhr in a [up:request:load](https://unpoly.com/up:request:load) event handler through the event.request.xhr property.

One use case is to add xhr event listeners. For example this is required to listen on upload progress events.

See #435.