### PR TITLE
Submit name/value from buttons outside the form

### DIFF
--- a/src/unpoly/form.js
+++ b/src/unpoly/form.js
@@ -184,13 +184,18 @@ up.form = (function() {
   */
   function submittingButton(form) {
     const selector = submitButtonSelector()
-    const focusedElement = up.viewport.focusedElementWithin(form)
-    if (focusedElement && focusedElement.matches(selector)) {
-      return focusedElement
-    } else {
-      // If no button is focused, we assume the first button in the form.
-      return e.get(form, selector)
+    const focusedElement = document.activeElement
+
+    // Use focused element only if it is a part of the submitted form.
+    if (focusedElement && focusedElement.form === form) {
+      // It must match the submit button selector as well.
+      if (focusedElement.matches(selector)) {
+        return focusedElement
+      }
     }
+
+    // If no button is focused, we assume the first button in the form.
+    return e.get(form, selector)
   }
 
   /*-


### PR DESCRIPTION
Submit buttons can be located outside of the `<form>` in question, but can still be a part of the form through the `form` attribute.

Make sure to detect this situation and submit the correct name/value pair in this case as well.

---

I am not sure this is the correct approach as I don't know much about browsers and JS, but it works for me.