### PR TITLE
Add examples and refine URL patterns docs

### DIFF
--- a/src/unpoly/pages/url-patterns.md
+++ b/src/unpoly/pages/url-patterns.md
@@ -1,9 +1,9 @@
 URL patterns
 ============
 
-Some Unpoly features like `a[up-alias]` let you match any URL with a given pattern.
+Certain Unpoly features like `a[up-alias]`, `a[up-accept]`, etc. will enable you match an URL with a given expression pattern. In Unpoly, these matching expressions are called `URL patterns`. URL patterns are a very powerful tool when closing layers, adding aliases to pages, and in many other situations.
 
-For this matching Unpoly does *not* use regular expressions, but the URL pattern format outlined below.
+This page describes the expression system Unpoly uses to match URL patterns. Please note that regular expressions (i.e., regexes) are not supported. You must use the expression system described on this page.
 
 ### Matching an exact URL
 
@@ -13,70 +13,171 @@ Pass any absolute path or fully qualified URL to only match this exact value:
 /users/new
 ```
 
+#### Examples
+
+First, let's look at a very simple use of an URL pattern, which matches one (and only one) specific URL.
+
+```html
+<!-- HTML
+Closes the new layer when user visits "/users/new" -->
+<a href="/users/" up-layer="new" up-accept-location="/users/new">Users</a>
+```
+
+```js
+/* JavaScript
+Closes the new layer when user visits '/users/new' */
+up.layer.open({ acceptLocation: "/users/new" });
+```
+
 ### Matching with wildcards
 
-Append an asterisk (`*`) to any path to match all URLs with that prefix:
+The asterisk (`*`) character matches one or many characters, numbers, or other valid special characters.
 
 ```text
 /users/*
 ```
 
-Prepend an asterisk to match all URLs with that suffix:
+In the above URL pattern, anything after `/users/` will be considered a match. For example, URLS like `/users/`, `/users/new`, `/users/123/edit`, etc. would all be considered a match for the URL pattern listed above.
+
+You can put asterisks anywhere in an URL pattern (you and even use more than one asterisk in a single URL pattern). For instance, to match any URL that ends in `/new` you can use the URL pattern Below
 
 ```text
-*/edit
+*/new
 ```
 
-You may also infix an asterisk to match URLs with the given prefix and suffix:
+The above URL pattern will match `/users/new`, `/admin/123/new`, etc.
+
+You may also place and asterisk in the middle of an URL pattern to match URLs with a given prefix and suffix:
 
 ```text
-/admin/*/edit
+/users/*/edit
+```
+
+The above URL pattern will match `/users/123/edit`, `/users/David/edit`, `/users/123/name/edit/`, etc.
+
+#### Examples
+
+Here are some practical examples of wildcard URL pattern prefixes.
+
+```html
+<!-- HTML
+Closes layer when user visits anything underneath "/users/" -->
+<a href="/users/" up-accept-location="/users/*" up-layer="new">Users</a>
+```
+
+```js
+/* JavaScript
+Closes layer when user visits anything underneath '/users/new' */
+up.layer.open({ acceptLocation: "/users/**" });
+```
+
+### Numeric-only wildcard matches
+
+The Dollar Sign (`$`) character will match any number (`0-9`) or numbers.
+
+```text
+/users/$/
+```
+
+The above URL pattern will match `/users/123`, `/users/123/edit`, etc.
+
+#### Examples
+
+```html
+<!-- HTML
+Closes layer when user visits any URL beginning with
+"/users/" and ends in a number or numbers -->
+<a href="/users/" up-accept-location="/users/$" up-layer="new">Users</a>
+```
+
+```js
+/* JavaScript
+Closes layer when user visits any URL beginning with
+'/users/' and ends in a number or numbers */
+up.layer.open({ acceptLocation: "/users/$" });
 ```
 
 ### Matching one of multiple alternatives
 
-To match one of multiple URLs or patterns, separate the alternatives by a space.
+To match one of multiple URL patterns, separate the URLs by a space within the pattern expression.
 
-The following will match either `/users/123` or `/account`:
+The URL pattern below will match either the `/users/123` or `/account` URLs:
 
 ```text
 /users/* /account
+```
+
+```html
+<!-- HTML
+Closes layer when user visits either /account or
+anything underneath "/users/" -->
+<a href="/users/" up-accept-location="/users/* /account" up-layer="new"
+  >Users</a
+>
 ```
 
 JavaScript functions that take URL patterns will accept multiple patterns
 as either a space-separated string or as an array of patterns:
 
 ```js
-up.layer.open({ acceptLocation: '/users/* /account' })
-up.layer.open({ acceptLocation: ['/users/*', '/account'] })
+// Javascript
+up.layer.open({ acceptLocation: "/users/* /account" });
+up.layer.open({ acceptLocation: ["/users/*", "/account"] });
 ```
 
-### Excluding patterns
+### Excluding pattern(s) from Matching
 
-To exclude an URL or pattern, prefix with a minus.
+To exclude an URL or pattern from matching, prefix the URL pattern with a minus (`-`) character.
 
-The following will match `/users/alice` but not `/users/new`:
+The following URL pattern will match the URL `/users/123` but not `/users/456`:
 
 ```text
-/users/* -/users/new
+/users/* -/users/456
+```
+
+#### Examples
+
+```html
+<!-- HTML
+Closes layer when user visits any URL beginning with
+"/users/" excluding  /users/456 -->
+<a href="/users/" up-accept-location="/users/* /users/456" up-layer="new"
+  >Users</a
+>
+```
+
+```js
+/* JavaScript
+Closes layer when user visits an URL beginning with
+'/users/' and ends in a number or numbers */
+up.layer.open({ acceptLocation: "/users/* /users/456" });
 ```
 
 ### Capturing named segments
 
-It is sometimes useful to capture the value of a wildcard match, e.g. to
+Sometimes it's useful to capture the value of the wildcard that was matched. For example to
 [close an overlay once a location is reached](/up.layer.open#options.acceptLocation).
-
-The following will capture `{ name: 'alice' }` from the path `/users/alice`:
 
 ```text
 /users/:name
 ```
 
-To only match digits (`0-9`), use the dollar symbol:
+#### Examples
 
-```text
-/users/$id
+```html
+<!-- HTML
+Closes layer when user visits any URL beginning with
+"/users/" and stores the value in userid -->
+<a href="/users/" up-accept-location="/users/:userid" up-layer="new">Users</a>
+```
+
+The URL the path `/users/alice` would return `{ name: 'alice' }`.
+
+```js
+/* JavaScript
+Closes layer when user visits an URL beginning with
+'/users/' and ends in a number or numbers */
+var userID = up.layer.open({ acceptLocation: `{ userid: 'alice' }` });
 ```
 
 @page url-patterns
-


### PR DESCRIPTION
Added to and refined the existing URL patterns documentation a fair bit.

- Added examples for all sections
- Made existing URL patterns more consistent throughout the document
- Misc. refinements and improvements
- Moved the numeric/digit wildcard matching section just under the wildcard section.

Pleases give the JavaScript examples particular scrutiny during your review.

Thanks for the great project. Unpoly gives my Django projects super powers from the future! :smiley: 