### PR TITLE
Update `up.element.classSelector` to escape non-alphanumeric/hyphen enabling support for more Tailwind JIT syntax

### DIFF
--- a/spec/unpoly/element_spec.coffee
+++ b/spec/unpoly/element_spec.coffee
@@ -1033,6 +1033,22 @@ describe 'up.element', ->
       element.classList.add('print:sm:hidden')
       expect(up.element.classSelector('print:sm:hidden')).toBe('.print\\:sm\\:hidden')
 
+    it 'escapes all square-brackets', ->
+      element = fixture('div')
+      element.classList.add('text-[2rem]')
+      expect(up.element.classSelector('text-[2rem]')).toBe('.text-\\[2rem\\]')
+
+    it 'escapes all periods', ->
+      element = fixture('div')
+      element.classList.add('text-[.8125rem]')
+      expect(up.element.classSelector('text-[.8125rem]')).toBe('.text-\\[\\.8125rem\\]')
+
+    it 'escapes all exclamation marks', ->
+      element = fixture('div')
+      element.classList.add('!font-bold')
+      expect(up.element.classSelector('!font-bold')).toBe('.\\!font-bold')
+
+
   describe 'up.element.hide()', ->
 
     it 'makes the given element invisible', ->

--- a/src/unpoly/element.js
+++ b/src/unpoly/element.js
@@ -683,7 +683,7 @@ up.element = (function() {
   @internal
   */
   function classSelector(klass) {
-    klass = klass.replace(/[:\[\]\.\!]/g, '\\$&')
+    klass = klass.replace(/[^\w-]/g, '\\$&')
     return `.${klass}`
   }
 

--- a/src/unpoly/element.js
+++ b/src/unpoly/element.js
@@ -683,7 +683,7 @@ up.element = (function() {
   @internal
   */
   function classSelector(klass) {
-    klass = klass.replace(/:/g, '\\:')
+    klass = klass.replace(/[:\[\]\.\!]/g, '\\$&')
     return `.${klass}`
   }
 


### PR DESCRIPTION
Update regular expression used for escaping class selector to escape any non-alphanumeric/hyphen characters.

Closes #492