### PR TITLE
Click events from disabled `<button>` elements should not propagate from their children

### DIFF
--- a/spec/unpoly/event_spec.js.coffee
+++ b/spec/unpoly/event_spec.js.coffee
@@ -36,6 +36,17 @@ describe 'up.event', ->
             jasmine.any(Object)
           )
 
+      it 'does not call the event listener if the event was triggered on a child and the selector has a [disabled] attribute', asyncSpec (next) ->
+        listener = jasmine.createSpy()
+        up.on('click', '.parent', listener)
+
+        $button = $fixture('button.parent[disabled]')
+        $child = $button.affix('span.child')
+
+        Trigger.click($child)
+        next =>
+          expect(listener.calls.count()).toBe(0)
+
       it 'passes the event target as the second argument if no selector was passed to up.on()', asyncSpec (next) ->
         $element = $fixture('.element')
         listener = jasmine.createSpy()
@@ -384,6 +395,7 @@ describe 'up.event', ->
 
           next =>
             expect(parseDataSpy).not.toHaveBeenCalled()
+
 
       if up.migrate.loaded
         it 'allows to bind and unbind events by their old, deprecated name', ->

--- a/spec/unpoly/event_spec.js.coffee
+++ b/spec/unpoly/event_spec.js.coffee
@@ -396,7 +396,6 @@ describe 'up.event', ->
           next =>
             expect(parseDataSpy).not.toHaveBeenCalled()
 
-
       if up.migrate.loaded
         it 'allows to bind and unbind events by their old, deprecated name', ->
           up.migrate.renamedEvent('up:spec:old', 'up:spec:new')

--- a/src/unpoly/classes/event_listener.js
+++ b/src/unpoly/classes/event_listener.js
@@ -90,6 +90,10 @@ up.EventListener = class EventListener extends up.Record {
         args.push(data)
       }
 
+      if (element instanceof HTMLButtonElement && element.disabled) {
+        return
+      }
+
       const applyCallback = this.callback.bind(element, ...args)
 
       if (this.baseLayer) {


### PR DESCRIPTION
I'm not really sure of this approach and would be fine refactoring or closing. It seemed simpler before I started the fix until I realized all of the different ways the browsers might interpret this.

Closes #443