### PR TITLE
Fix link to `[up-feedback]` attribute

### DIFF
--- a/src/unpoly/pages/watch-options.md
+++ b/src/unpoly/pages/watch-options.md
@@ -143,7 +143,7 @@ When you don't write the callback manually (`up.autosubmit()`, `up.validate()`) 
 worry about returning a promise.
 
 > [TIP]
-To show navigation feedback while *submitting* (instead of while watching), use [`[up-feedback]`](/disabling-forms) instead.
+To show navigation feedback while *submitting* (instead of while watching), use [`[up-feedback]`](/a-up-follow#up-feedback) instead.
 
 
 Setting options for multiple fields


### PR DESCRIPTION
I believe it should point to [this page](https://unpoly.com/a-up-follow#up-feedback) instead. But it could be suitable to [this page](https://unpoly.com/up.feedback). WDYT?