### PR TITLE
Use contains function from Node prototype

### DIFF
--- a/spec/unpoly/element_spec.coffee
+++ b/spec/unpoly/element_spec.coffee
@@ -204,6 +204,13 @@ describe 'up.element', ->
       results = up.element.subtree($element[0], '.match')
       expect(results).toEqual []
 
+  describe 'up.element.isInSubtree()', ->
+    it 'can handle conflicts with forms where an input is named `contains` GH#507', ->
+      $form = $fixture('form')
+      $child = $form.affix('input[name="contains"]')
+
+      expect(up.element.isInSubtree($form[0], $child)).toBe(true)
+
   if up.migrate.loaded
     describe 'up.element.closest()', ->
 

--- a/src/unpoly/element.js
+++ b/src/unpoly/element.js
@@ -75,7 +75,7 @@ up.element = (function() {
   */
   function isInSubtree(root, selectorOrElement) {
     const element = getOne(selectorOrElement)
-    return root.contains(element)
+    return Node.prototype.contains.call(root, element)
   }
 
   /*-


### PR DESCRIPTION
When checking if in subtree where the root is `HTMLFormElement`, there is a chance that `root.contains` is actually another form element, and not the function `contains`.

To work around this, use the prototype function directly from Node.

Closes #507