### PR TITLE
[docs] Add a link from up.on to up.event.halt

### DIFF
--- a/src/unpoly/event.js
+++ b/src/unpoly/event.js
@@ -53,6 +53,7 @@ up.event = (function() {
   - You may register a listener to multiple events by passing a space-separated list of event name (e.g. `"click mousedown"`)
   - You may register a listener to multiple elements in a single `up.on()` call, by passing a [list](/up.util.isList) of elements.
   - Any [data attached to the observed element](/data) will be passed as a third argument to your handler function.
+  - You can prevent the event from being processed further with [up.event.halt(event)](/up.event.halt).
 
   ### Basic example
 

--- a/src/unpoly/event.js
+++ b/src/unpoly/event.js
@@ -53,7 +53,8 @@ up.event = (function() {
   - You may register a listener to multiple events by passing a space-separated list of event name (e.g. `"click mousedown"`)
   - You may register a listener to multiple elements in a single `up.on()` call, by passing a [list](/up.util.isList) of elements.
   - Any [data attached to the observed element](/data) will be passed as a third argument to your handler function.
-  - You can prevent the event from being processed further with [up.event.halt(event)](/up.event.halt).
+
+  You can prevent the event from being processed further with [up.event.halt(event)](/up.event.halt).
 
   ### Basic example
 


### PR DESCRIPTION
I was searching how to achieve something like `return false` in jQuery within `up.on`. And maybe it would helped me if there was an explizit link to `up.event.halt`.

Note: I was not able to test the documentation.