### PR TITLE
Changed typo in label 'for' value

### DIFF
--- a/src/unpoly/pages/dependent-fields.md
+++ b/src/unpoly/pages/dependent-fields.md
@@ -22,7 +22,7 @@ We can implement this form with three `[up-validate]` attributes and no addition
 ```html
 <form method="post" action="/purchases">
   <fieldset>
-    <label for="content">Continent</label>
+    <label for="continent">Continent</label>
     <select name="continent" id="continent" up-validate="#country">...</select> <!-- mark-phrase "up-validate" -->
   </fieldset>
   


### PR DESCRIPTION
The first code block on the `Dependent Fields` page had a label with the `for` attribute pointing to the id "content", which was used nowhere. 

Fixed what I believe to be a typo (from looking around other files and references within the same file)