### PR TITLE
fix typo in form.js 'hader' => 'header'

### DIFF
--- a/src/unpoly/form.js
+++ b/src/unpoly/form.js
@@ -1503,7 +1503,7 @@ up.form = (function() {
   Unpoly will always consider a validation request to be successful, even if the
   server responds with a non-200 status code.
 
-  Upon seeing an `X-Up-Validate` hader, the server now renders a new state form from request parameters,
+  Upon seeing an `X-Up-Validate` header, the server now renders a new state form from request parameters,
   showing eventual validation errors and updating [dependent fields](/dependent-fields):
 
   ```html


### PR DESCRIPTION
Hey! 
what a great library!

I found a typo while reading the documentations.