### PR TITLE
Fix documentation on predefined transitions

### DIFF
--- a/src/unpoly/pages/predefined-transitions.md
+++ b/src/unpoly/pages/predefined-transitions.md
@@ -5,19 +5,14 @@ Unpoly ships with a number of generic [transitions](/up.motion#transitions)
 you can use in an `[up-transition]` attribute or a `{ transition }` option:
 
 
-| Animation          | Visual effect  |
-|--------------------|----------------|
-| `fade-in`          | Changes the element's opacity from 0% to 100% |
-| `fade-out`         | Changes the element's opacity from 100% to 0% |
-| `move-to-top`      | Moves the element upwards until it exits the screen at the top edge |
-| `move-from-top`    | Moves the element downwards from beyond the top edge of the screen until it reaches its current position |
-| `move-to-bottom`   | Moves the element downwards until it exits the screen at the bottom edge |
-| `move-from-bottom` | Moves the element upwards from beyond the bottom edge of the screen until it reaches its current position |
-| `move-to-left`     | Moves the element leftwards until it exists the screen at the left edge |
-| `move-from-left`   | Moves the element rightwards from beyond the left edge of the screen until it reaches its current position |
-| `move-to-right`    | Moves the element rightwards until it exists the screen at the right edge |
-| `move-from-right`  | Moves the element leftwards from beyond the right  edge of the screen until it reaches its current position |
-| `none`             | An animation that has no visible effect. Sounds useless at first, but can save you a lot of `if` statements. |
+| Transition   | Visual effect  |
+|--------------|----------------|
+| `cross-fade` | Fades out the first element. Simultaneously fades in the second element. |
+| `move-up`    | Moves the first element upwards until it exits the screen at the top edge. Simultaneously moves the second element upwards from beyond the bottom edge of the screen until it reaches its current position. |
+| `move-down`  | Moves the first element downwards until it exits the screen at the bottom edge. Simultaneously moves the second element downwards from beyond the top edge of the screen until it reaches its current position. |
+| `move-left`  | Moves the first element leftwards until it exists the screen at the left edge. Simultaneously moves the second element leftwards from beyond the right  edge of the screen until it reaches its current position. |
+| `move-right` | Moves the first element rightwards until it exists the screen at the right edge. Simultaneously moves the second element rightwards from beyond the left edge of the screen until it reaches its current position. |
+| `none`       | A transition that has no visible effect. Sounds useless at first, but can save you a lot of `if` statements. |
 
 
 ## Combining animations


### PR DESCRIPTION
I noticed that the description of predefined transitions do not match examples.

I suppose that was copy-paste error during docs refactoring 5b87174 so I changed it to more probable fragment.