### PR TITLE
Fix flickering focus outline for .up-focus-hidden elements

### DIFF
--- a/src/unpoly/viewport.sass
+++ b/src/unpoly/viewport.sass
@@ -2,7 +2,7 @@ up-bounds
   position: absolute
 
 .up-focus-hidden:focus-visible
-  outline: none !important
+  outline-color: transparent !important
 
 body.up-scrollbar-away
   overflow-y: hidden !important


### PR DESCRIPTION
The current implementation of `.up-focus-hidden:focus-visible` can cause outline flickering in projects which transition the outline color.

## Background

The previous style of `outline: none` expands into the following style definitions.
```css
outline-color: initial;
outline-style: none;
outline-width: initial;
```

Unfortunately, `outline-color: initial` means `outline-color: currentColor`.

## Issue

This causes issues with application which transition the `outline-color` property on elements.

If an `.up-focus-visible` element is `:focus-visible` only for a brief moment (e.g. when clicking a link, Chrome applies `:focus-visible` just to remove it right after), the element's transition rules will then cause a transition of `outline-color` starting with `currentColor`. This is usually not desired and looks like a flickering outline.

## Solution

IMO, defining only a transparent outline color is a good default without such side effects.

If the goal is to not show an outline, we can just hide it by making it transparent. Since outlines do not consume layout space, other outline properties can be kept.

If you feel like you want to keep using the `outline` shorthand property, `outline: 0 transparent !important` would also work.