### PR TITLE
Add tel links to noFollowSelectors

### DIFF
--- a/spec/unpoly/link_spec.js.coffee
+++ b/spec/unpoly/link_spec.js.coffee
@@ -2001,6 +2001,17 @@ describe 'up.link', ->
             expect(followSpy).not.toHaveBeenCalled()
             expect(link).toHaveBeenDefaultFollowed()
 
+        it 'never follows a link with a "tel:..." [href] attribute', asyncSpec (next) ->
+          followSpy = up.link.follow.mock().and.returnValue(Promise.resolve())
+          up.link.config.followSelectors.push('a[href]')
+          link = up.hello fixture('a[href="tel:+49123456"]')
+
+          Trigger.click(link)
+
+          next ->
+            expect(followSpy).not.toHaveBeenCalled()
+            expect(link).toHaveBeenDefaultFollowed()
+
         it 'never follows a link with a "whatsapp://..." attribute', asyncSpec (next) ->
           followSpy = up.link.follow.mock().and.returnValue(Promise.resolve())
           up.link.config.followSelectors.push('a[href]')

--- a/src/unpoly/link.js
+++ b/src/unpoly/link.js
@@ -202,7 +202,7 @@ up.link = (function() {
     //     Many web developers are used to give JavaScript-handled links an [href="#"]
     //     attribute. Also frameworks like Bootstrap only style links if they have an [href].
     // (3) We don't want to handle <a href="javascript:foo()"> links.
-    noFollowSelectors: ['[up-follow=false]', 'a[download]', 'a[target]', 'a[href^="javascript:"]', 'a[href^="mailto:"]', `a[href^="#"]:not(${ATTRS_WITH_LOCAL_HTML})`, e.crossOriginSelector('href'), e.crossOriginSelector('up-href')],
+    noFollowSelectors: ['[up-follow=false]', 'a[download]', 'a[target]', 'a[href^="javascript:"]', 'a[href^="mailto:"]', 'a[href^="tel:"]', `a[href^="#"]:not(${ATTRS_WITH_LOCAL_HTML})`, e.crossOriginSelector('href'), e.crossOriginSelector('up-href')],
 
     instantSelectors: ['[up-instant]'],
     noInstantSelectors: ['[up-instant=false]', '[onclick]'],


### PR DESCRIPTION
There is a (new?) behavior in browsers that I've noticed: When preloading a link with a `tel`-`href`, the browser issues a warning. In Chrome, the `tel`-link is even visible through the browser's address bar. I don't know if this is another potential problem that should be investigated.

![image](https://github.com/user-attachments/assets/4f381b08-a5a1-491d-ad8e-b41e7ff005fe)
