### PR TITLE
Use "overflow-y: clip" instead of "overflow-y: hidden" when scrollbar is hidden

### DIFF
--- a/src/unpoly/viewport.sass
+++ b/src/unpoly/viewport.sass
@@ -14,6 +14,7 @@ up-bounds
 body.up-scrollbar-away
   &, html:has(>&)
     overflow-y: hidden !important
+    overflow-y: clip !important
 
   padding-right: calc(var(--up-scrollbar-width) + var(--up-original-padding-right)) !important
 


### PR DESCRIPTION
I believe we should be using `overflow-y: clip` instead of `overflow-y: hidden` when the body scrollbar is hidden.

Using `clip` allows elements with `position: sticky` to stay at their sticky position. With `hidden`, a sticky toolbar would disappear when the user scrolled down and opens a modal.

Browsers which don't support `clip` ([basically just Safari <16](https://caniuse.com/mdn-css_types_overflow_clip)) would fall back to using `hidden`.