### PR TITLE
Include form-associated custom elements in form submissions

### DIFF
--- a/spec/unpoly/classes/params_spec.js
+++ b/spec/unpoly/classes/params_spec.js
@@ -449,6 +449,57 @@ describe('up.Params', function() {
       ])
     })
 
+    it('includes values added by a [formdata] event listener', function() {
+      const $form = $fixture('form')
+      $form[0].addEventListener('formdata', function(event) {
+        event.formData.append('key', 'value')
+      })
+
+      const params = up.Params.fromForm($form)
+      expect(params.toArray()).toEqual([
+        { name: 'key', value: 'value' },
+      ])
+    })
+
+    it('includes a non-native field configured with up.form.config.fieldSelectors', function() {
+      up.form.config.fieldSelectors.push('test-form-field')
+      const $form = $fixture('form')
+      const $field = $('<test-form-field></test-form-field>').appendTo($form)
+      $field[0].name = 'key'
+      $field[0].value = 'value'
+
+      const params = up.Params.fromForm($form)
+      expect(params.toArray()).toEqual([
+        { name: 'key', value: 'value' },
+      ])
+    })
+
+    if (window.customElements && HTMLElement.prototype.attachInternals) {
+      class TestFormAssociatedElement extends HTMLElement {
+        constructor() {
+          super()
+          this.internals = this.attachInternals()
+        }
+
+        connectedCallback() {
+          this.internals.setFormValue(this.getAttribute('value'))
+        }
+      }
+
+      TestFormAssociatedElement.formAssociated = true
+      window.customElements.define('test-form-associated-element', TestFormAssociatedElement)
+
+      it('serializes a form-associated custom element', function() {
+        const $form = $fixture('form')
+        $form.append('<test-form-associated-element name="key" value="value"></test-form-associated-element>')
+
+        const params = up.Params.fromForm($form)
+        expect(params.toArray()).toEqual([
+          { name: 'key', value: 'value' },
+        ])
+      })
+    }
+
     it('serializes an <input type="text"> with its default [value]', function() {
       const $form = $fixture('form')
       $form.append('<input type="text" name="key" value="value-from-attribute">')
@@ -638,4 +689,3 @@ describe('up.Params', function() {
     })
   })
 })
-

--- a/src/unpoly/classes/params.js
+++ b/src/unpoly/classes/params.js
@@ -474,6 +474,8 @@ up.Params = class Params {
   - If passed a `<select multiple>` or `<input type="file" multiple>`, all selected values are added.
   - Fields that are `[disabled]` are ignored.
   - Fields without a `[name]` attribute are ignored.
+  - Form-associated custom elements and values added by `formdata` event listeners are included.
+  - Custom controls configured with `up.form.config.fieldSelectors` are included.
 
   ### Example
 

--- a/src/unpoly/classes/params.js
+++ b/src/unpoly/classes/params.js
@@ -502,7 +502,11 @@ up.Params = class Params {
   @stable
   */
   static fromForm(form, options) {
-    return this.fromContainer(form, options)
+    form = e.get(form)
+    const params = new this(new FormData(form), options)
+    const additionalFields = u.reject(up.form.fields(form), (field) => u.contains(form.elements, field))
+    params.addAll(this.fromFields(additionalFields, options))
+    return params
   }
 
   static fromContainer(container, options) {


### PR DESCRIPTION
This pull request fixes [the original issue #593](https://github.com/unpoly/unpoly/issues/593).

I develop [Viewflow.io](https://viewflow.io/) and am evaluating alternatives to Turbolinks, Hotwire/Turbo, and htmx. During that work, I found a discrepancy in Unpoly. An `[up-submit]` form dropped values from form-associated custom elements. A normal browser submission included them.

## What changes

`up.Params.fromForm()` now begins with native `FormData(form)`. It uses the browser's form-data construction algorithm. This includes form-associated custom elements and values appended by `formdata` listeners.

The method then adds configured Unpoly fields that are absent from `form.elements`. This keeps `up.form.config.fieldSelectors` working for non-native controls. It does not duplicate native or form-associated controls.

This is a small submission-only change. It does not change `up.Params.fromContainer()` or Unpoly's watcher behavior.

## Compatibility

Existing native controls keep browser submission semantics. Configured custom controls still submit when they expose `name`, `value`, and `disabled` properties.

## Verification

- I added specs for `formdata` listeners, form-associated custom elements, and configured non-native controls.
- I ran `npm run lint`, `npm run build-ci`, and the focused Chrome `up.Params` suite.

## Authorship

This PR was AI-assisted and made with Codex Terra. I reviewed every line and take responsibility for the code.
